### PR TITLE
worktree: protect main branch from deletion

### DIFF
--- a/internal/plugins/worktree/mouse.go
+++ b/internal/plugins/worktree/mouse.go
@@ -317,12 +317,14 @@ func (p *Plugin) handleMouseClick(action mouse.MouseAction) tea.Cmd {
 		p.agentChoiceWorktree = nil
 		p.agentChoiceButtonFocus = 0
 	case regionDeleteLocalBranchCheck:
-		// Click on local branch checkbox
-		p.deleteLocalBranchOpt = !p.deleteLocalBranchOpt
-		p.deleteConfirmFocus = 0
+		// Click on local branch checkbox (disabled for main branch)
+		if !p.deleteIsMainBranch {
+			p.deleteLocalBranchOpt = !p.deleteLocalBranchOpt
+			p.deleteConfirmFocus = 0
+		}
 	case regionDeleteRemoteBranchCheck:
-		// Click on remote branch checkbox (only if remote exists)
-		if p.deleteHasRemote {
+		// Click on remote branch checkbox (only if remote exists, disabled for main branch)
+		if !p.deleteIsMainBranch && p.deleteHasRemote {
 			p.deleteRemoteBranchOpt = !p.deleteRemoteBranchOpt
 			p.deleteConfirmFocus = 1
 		}

--- a/internal/plugins/worktree/plugin.go
+++ b/internal/plugins/worktree/plugin.go
@@ -236,6 +236,7 @@ type Plugin struct {
 	deleteLocalBranchOpt     bool      // Checkbox: delete local branch
 	deleteRemoteBranchOpt    bool      // Checkbox: delete remote branch
 	deleteHasRemote          bool      // Whether remote branch exists
+	deleteIsMainBranch       bool      // Whether the worktree branch is the main branch (protected)
 	deleteConfirmFocus       int       // 0=local checkbox, 1=remote checkbox (if exists), then delete/cancel btns
 	deleteWarnings           []string  // Warnings from last delete operation (e.g., branch deletion failures)
 


### PR DESCRIPTION
Add a universal guard preventing deletion of the repository's primary
branch (main/master) both locally and remotely. When deleting a worktree
that is on the main branch, the branch cleanup checkboxes are hidden
from the delete modal entirely, and the deleteBranch/deleteRemoteBranchCmd
functions refuse to operate on the main branch as a last-line defense.