### PR TITLE
merge modal: show file summary instead of code diff

### DIFF
--- a/internal/plugins/worktree/merge.go
+++ b/internal/plugins/worktree/merge.go
@@ -268,13 +268,12 @@ func (p *Plugin) proceedToMergeWorkflow(wt *Worktree) tea.Cmd {
 	return p.loadMergeDiff(wt)
 }
 
-// loadMergeDiff loads the diff summary for the merge workflow.
+// loadMergeDiff loads the diff file summary for the merge workflow.
 func (p *Plugin) loadMergeDiff(wt *Worktree) tea.Cmd {
 	return func() tea.Msg {
-		// Get diff against base branch
 		baseBranch := resolveBaseBranch(wt)
 
-		diff, err := getDiffFromBase(wt.Path, baseBranch)
+		stat, err := getDiffStatFromBase(wt.Path, baseBranch)
 		if err != nil {
 			return MergeStepCompleteMsg{
 				WorktreeName: wt.Name,
@@ -284,13 +283,10 @@ func (p *Plugin) loadMergeDiff(wt *Worktree) tea.Cmd {
 			}
 		}
 
-		// Get a summary (stat output)
-		summary, _ := getDiffSummary(wt.Path)
-
 		return MergeStepCompleteMsg{
 			WorktreeName: wt.Name,
 			Step:         MergeStepReviewDiff,
-			Data:         summary + "\n\n" + truncateDiff(diff, 50),
+			Data:         stat,
 		}
 	}
 }

--- a/internal/plugins/worktree/view_diff.go
+++ b/internal/plugins/worktree/view_diff.go
@@ -269,3 +269,41 @@ func (p *Plugin) colorDiffLine(line string, width int) string {
 		return line
 	}
 }
+
+// colorStatLine applies coloring to git --stat output lines.
+// Colors the +/- bar graph characters green/red.
+func (p *Plugin) colorStatLine(line string, width int) string {
+	if len(line) == 0 {
+		return line
+	}
+
+	// Truncate if needed
+	if lipgloss.Width(line) > width {
+		line = p.truncateCache.Truncate(line, width, "")
+	}
+
+	// Find the | separator that precedes the bar graph
+	pipeIdx := strings.LastIndex(line, "|")
+	if pipeIdx == -1 {
+		// Summary line or no bar graph - render as-is
+		return line
+	}
+
+	prefix := line[:pipeIdx+1]
+	bar := line[pipeIdx+1:]
+
+	// Color individual + and - characters in the bar portion
+	var colored strings.Builder
+	colored.WriteString(prefix)
+	for _, ch := range bar {
+		switch ch {
+		case '+':
+			colored.WriteString(styles.DiffAdd.Render("+"))
+		case '-':
+			colored.WriteString(styles.DiffRemove.Render("-"))
+		default:
+			colored.WriteRune(ch)
+		}
+	}
+	return colored.String()
+}

--- a/internal/plugins/worktree/view_modals.go
+++ b/internal/plugins/worktree/view_modals.go
@@ -1259,7 +1259,7 @@ func (p *Plugin) renderMergeModal(width, height int) string {
 	// Step-specific content
 	switch p.mergeState.Step {
 	case MergeStepReviewDiff:
-		sb.WriteString(lipgloss.NewStyle().Bold(true).Render("Diff Summary:"))
+		sb.WriteString(lipgloss.NewStyle().Bold(true).Render("Files Changed:"))
 		sb.WriteString("\n\n")
 		if p.mergeState.DiffSummary != "" {
 			// Truncate to fit modal
@@ -1270,14 +1270,14 @@ func (p *Plugin) renderMergeModal(width, height int) string {
 			}
 			if len(summaryLines) > maxLines {
 				summaryLines = summaryLines[:maxLines]
-				summaryLines = append(summaryLines, fmt.Sprintf("... (%d more lines)", len(strings.Split(p.mergeState.DiffSummary, "\n"))-maxLines))
+				summaryLines = append(summaryLines, fmt.Sprintf("... (%d more files)", len(strings.Split(p.mergeState.DiffSummary, "\n"))-maxLines))
 			}
 			for _, line := range summaryLines {
-				sb.WriteString(p.colorDiffLine(line, modalW-4))
+				sb.WriteString(p.colorStatLine(line, modalW-4))
 				sb.WriteString("\n")
 			}
 		} else {
-			sb.WriteString(dimText("Loading diff..."))
+			sb.WriteString(dimText("Loading..."))
 			sb.WriteString("\n")
 		}
 		sb.WriteString("\n")


### PR DESCRIPTION
Replace the full code diff in the merge workflow's review step with a
file-level stat summary (additions/deletions per file). This makes
the modal more readable; users can escape to review line-level changes.