### PR TITLE
feat: add commit message normalization

### DIFF
--- a/internal/plugins/gitstatus/commit_normalize.go
+++ b/internal/plugins/gitstatus/commit_normalize.go
@@ -1,0 +1,52 @@
+package gitstatus
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// NormalizeCommitMessage standardizes a commit message by trimming whitespace,
+// capitalizing the subject line, removing trailing periods, stripping trailing
+// blank lines, and truncating subjects over 72 characters.
+func NormalizeCommitMessage(msg string) string {
+	msg = strings.TrimSpace(msg)
+	if msg == "" {
+		return msg
+	}
+
+	lines := strings.Split(msg, "\n")
+
+	// Normalize subject line (first line)
+	subject := strings.TrimSpace(lines[0])
+	subject = capitalizeFirst(subject)
+	subject = strings.TrimRight(subject, ".")
+	subject = truncateSubject(subject, 72)
+	lines[0] = subject
+
+	// Strip trailing blank lines
+	for len(lines) > 1 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func capitalizeFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	r, size := utf8.DecodeRuneInString(s)
+	if r == utf8.RuneError {
+		return s
+	}
+	return string(unicode.ToUpper(r)) + s[size:]
+}
+
+func truncateSubject(s string, max int) string {
+	if utf8.RuneCountInString(s) <= max {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:max-1]) + "…"
+}

--- a/internal/plugins/gitstatus/commit_normalize_test.go
+++ b/internal/plugins/gitstatus/commit_normalize_test.go
@@ -1,0 +1,101 @@
+package gitstatus
+
+import "testing"
+
+func TestNormalizeCommitMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "trims whitespace",
+			in:   "  fix bug  ",
+			want: "Fix bug",
+		},
+		{
+			name: "capitalizes first letter",
+			in:   "fix bug",
+			want: "Fix bug",
+		},
+		{
+			name: "already capitalized unchanged",
+			in:   "Fix bug",
+			want: "Fix bug",
+		},
+		{
+			name: "removes trailing period",
+			in:   "Fix bug.",
+			want: "Fix bug",
+		},
+		{
+			name: "removes multiple trailing periods",
+			in:   "Fix bug...",
+			want: "Fix bug",
+		},
+		{
+			name: "strips trailing blank lines",
+			in:   "Fix bug\n\n",
+			want: "Fix bug",
+		},
+		{
+			name: "strips multiple trailing blank lines",
+			in:   "Fix bug\n\n\n\n",
+			want: "Fix bug",
+		},
+		{
+			name: "truncates long subject",
+			in:   "This is a very long commit message that exceeds the seventy-two character limit for subject lines",
+			want: "This is a very long commit message that exceeds the seventy-two charact…",
+		},
+		{
+			name: "preserves multi-line body",
+			in:   "Fix bug\n\nThis is the body of the commit message.\nIt has multiple lines.",
+			want: "Fix bug\n\nThis is the body of the commit message.\nIt has multiple lines.",
+		},
+		{
+			name: "normalizes subject preserves body",
+			in:   "fix bug.\n\ndetailed description here.",
+			want: "Fix bug\n\ndetailed description here.",
+		},
+		{
+			name: "empty string unchanged",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "whitespace only returns empty",
+			in:   "   \n  \n  ",
+			want: "",
+		},
+		{
+			name: "already conforming unchanged",
+			in:   "Add feature X",
+			want: "Add feature X",
+		},
+		{
+			name: "multi-line with trailing blanks stripped",
+			in:   "Fix bug\n\nBody text\n\n\n",
+			want: "Fix bug\n\nBody text",
+		},
+		{
+			name: "exactly 72 chars not truncated",
+			in:   "123456789012345678901234567890123456789012345678901234567890123456789012",
+			want: "123456789012345678901234567890123456789012345678901234567890123456789012",
+		},
+		{
+			name: "73 chars truncated",
+			in:   "1234567890123456789012345678901234567890123456789012345678901234567890123",
+			want: "12345678901234567890123456789012345678901234567890123456789012345678901…",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeCommitMessage(tt.in)
+			if got != tt.want {
+				t.Errorf("NormalizeCommitMessage(%q)\n got: %q\nwant: %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/plugins/gitstatus/update_handlers.go
+++ b/internal/plugins/gitstatus/update_handlers.go
@@ -809,7 +809,7 @@ func (p *Plugin) updateCommit(msg tea.KeyMsg) (plugin.Plugin, tea.Cmd) {
 
 // tryCommit attempts to execute the commit (or amend) if message is valid.
 func (p *Plugin) tryCommit() tea.Cmd {
-	message := strings.TrimSpace(p.commitMessage.Value())
+	message := NormalizeCommitMessage(p.commitMessage.Value())
 	if message == "" {
 		p.commitError = "Commit message cannot be empty"
 		return nil


### PR DESCRIPTION
## Summary
- Add `NormalizeCommitMessage()` function that standardizes commit messages: trims whitespace, capitalizes subject line, removes trailing periods, strips trailing blank lines, and truncates subjects over 72 chars with ellipsis
- Wire normalization into `tryCommit()` so it applies transparently before messages reach git
- Add comprehensive table-driven tests covering all normalization cases

## Test plan
- [x] All existing tests pass (`go test ./internal/plugins/gitstatus/...`)
- [x] New `TestNormalizeCommitMessage` covers: whitespace trimming, capitalization, trailing period removal, trailing blank line stripping, 72-char truncation, multi-line body preservation, empty/whitespace-only passthrough, already-conforming messages
- [x] Full build succeeds (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)