### PR TITLE
fix: unset TMUX env var for nested tmux sessions

### DIFF
--- a/cmd/sidecar/main.go
+++ b/cmd/sidecar/main.go
@@ -56,6 +56,11 @@ var (
 func main() {
 	flag.Parse()
 
+	// Unset TMUX so sidecar's internal tmux sessions are independent of any
+	// outer tmux session. This allows prefix+d to detach from the workspace's
+	// inner session rather than the user's outer tmux.
+	os.Unsetenv("TMUX")
+
 	// Start pprof server if enabled (for memory profiling)
 	if pprofPort := os.Getenv("SIDECAR_PPROF"); pprofPort != "" {
 		if pprofPort == "1" {


### PR DESCRIPTION
## Summary
- When running sidecar inside tmux, pressing `prefix+d` to detach from a workspace shell would detach the **outer** tmux session instead of the workspace's inner session
- Fix: unset the `TMUX` environment variable at startup so sidecar's internal tmux sessions are independent of any enclosing tmux

## Test plan
- [ ] Run sidecar inside a tmux session
- [ ] Open a workspace and press `t` to attach to a shell
- [ ] Press `prefix+d` — should return to sidecar's UI, not detach the outer tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)