### PR TITLE
fix: git plugin tracks selected workspace on tab switch

### DIFF
--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -101,21 +101,21 @@ type Model struct {
 	activeContext string
 
 	// UI state
-	width, height    int
-	showHelp         bool
-	helpModal        *modal.Modal
-	helpModalWidth   int
-	helpMouseHandler *mouse.Handler
+	width, height           int
+	showHelp                bool
+	helpModal               *modal.Modal
+	helpModalWidth          int
+	helpMouseHandler        *mouse.Handler
 	showDiagnostics         bool
 	diagnosticsModal        *modal.Modal
 	diagnosticsModalWidth   int
 	diagnosticsMouseHandler *mouse.Handler
 	showClock               bool
-	showPalette      bool
-	showQuitConfirm  bool
-	quitModal        *modal.Modal
-	quitMouseHandler *mouse.Handler
-	palette          palette.Model
+	showPalette             bool
+	showQuitConfirm         bool
+	quitModal               *modal.Modal
+	quitMouseHandler        *mouse.Handler
+	palette                 palette.Model
 
 	// Project switcher modal
 	showProjectSwitcher         bool
@@ -161,15 +161,15 @@ type Model struct {
 	cachedWorktreeInfo *WorktreeInfo
 
 	// Theme switcher modal
-	showThemeSwitcher          bool
-	themeSwitcherModal         *modal.Modal
-	themeSwitcherModalWidth    int
-	themeSwitcherMouseHandler  *mouse.Handler
-	themeSwitcherSelectedIdx   int
-	themeSwitcherInput         textinput.Model
-	themeSwitcherFiltered      []themeEntry
-	themeSwitcherOriginal      themeEntry // original theme to restore on cancel
-	themeSwitcherScope         string     // "global" or "project"
+	showThemeSwitcher         bool
+	themeSwitcherModal        *modal.Modal
+	themeSwitcherModalWidth   int
+	themeSwitcherMouseHandler *mouse.Handler
+	themeSwitcherSelectedIdx  int
+	themeSwitcherInput        textinput.Model
+	themeSwitcherFiltered     []themeEntry
+	themeSwitcherOriginal     themeEntry // original theme to restore on cancel
+	themeSwitcherScope        string     // "global" or "project"
 
 	// Issue preview - input phase
 	showIssueInput         bool
@@ -179,11 +179,11 @@ type Model struct {
 	issueInputMouseHandler *mouse.Handler
 
 	// Issue input auto-complete
-	issueSearchResults      []IssueSearchResult
-	issueSearchQuery        string // last query sent to td search
-	issueSearchLoading      bool
-	issueSearchCursor       int  // selected result index (-1 = none/input focused)
-	issueSearchScrollOffset int  // viewport scroll offset for search results
+	issueSearchResults       []IssueSearchResult
+	issueSearchQuery         string // last query sent to td search
+	issueSearchLoading       bool
+	issueSearchCursor        int  // selected result index (-1 = none/input focused)
+	issueSearchScrollOffset  int  // viewport scroll offset for search results
 	issueSearchIncludeClosed bool // whether to include closed issues in search
 
 	// Issue preview - preview phase
@@ -233,20 +233,20 @@ type Model struct {
 	changelogScrollState  *changelogViewState // Shared state for modal closure
 
 	// Update modal (declarative)
-	updatePreviewModal        *modal.Modal
-	updatePreviewModalWidth   int
-	updatePreviewMouseHandler *mouse.Handler
-	updateCompleteModal       *modal.Modal
-	updateCompleteModalWidth  int
+	updatePreviewModal         *modal.Modal
+	updatePreviewModalWidth    int
+	updatePreviewMouseHandler  *mouse.Handler
+	updateCompleteModal        *modal.Modal
+	updateCompleteModalWidth   int
 	updateCompleteMouseHandler *mouse.Handler
-	updateErrorModal          *modal.Modal
-	updateErrorModalWidth     int
-	updateErrorMouseHandler   *mouse.Handler
-	changelogModal            *modal.Modal
-	changelogModalWidth       int
-	changelogMouseHandler     *mouse.Handler
-	changelogRenderedLines    []string // Cached rendered changelog lines
-	changelogMaxVisibleLines  int      // Max lines visible in viewport
+	updateErrorModal           *modal.Modal
+	updateErrorModalWidth      int
+	updateErrorMouseHandler    *mouse.Handler
+	changelogModal             *modal.Modal
+	changelogModalWidth        int
+	changelogMouseHandler      *mouse.Handler
+	changelogRenderedLines     []string // Cached rendered changelog lines
+	changelogMaxVisibleLines   int      // Max lines visible in viewport
 
 	// Intro animation
 	intro IntroModel
@@ -272,16 +272,16 @@ func New(reg *plugin.Registry, km *keymap.Registry, cfg *config.Config, currentV
 	}
 
 	return Model{
-		cfg:                   cfg,
-		registry:              reg,
-		keymap:                km,
-		activePlugin:          activeIdx,
-		activeContext:         "global",
-		showClock:             cfg.UI.ShowClock,
-		palette:               palette.New(),
-		ui:                    ui,
-		ready:                 false,
-		intro:                 NewIntroModel(repoName),
+		cfg:               cfg,
+		registry:          reg,
+		keymap:            km,
+		activePlugin:      activeIdx,
+		activeContext:     "global",
+		showClock:         cfg.UI.ShowClock,
+		palette:           palette.New(),
+		ui:                ui,
+		ready:             false,
+		intro:             NewIntroModel(repoName),
 		currentVersion:    currentVersion,
 		updatePhaseStatus: make(map[UpdatePhase]string),
 	}
@@ -339,11 +339,36 @@ func (m Model) ActivePlugin() plugin.Plugin {
 func (m *Model) SetActivePlugin(idx int) tea.Cmd {
 	plugins := m.registry.Plugins()
 	if idx >= 0 && idx < len(plugins) {
-		// Unfocus current
+		// Check if the leaving plugin provides workspace context (e.g., workspace manager
+		// has a worktree selected). If so, switch the global context to that worktree
+		// so other plugins (git status, file browser, etc.) show the correct state.
+		var needsWorktreeSwitch string
 		if current := m.ActivePlugin(); current != nil {
+			if wcp, ok := current.(plugin.WorkspaceContextProvider); ok {
+				if selectedDir := wcp.SelectedWorkDir(); selectedDir != "" {
+					normalizedSelected, _ := normalizePath(selectedDir)
+					normalizedCurrent, _ := normalizePath(m.ui.WorkDir)
+					if normalizedSelected != normalizedCurrent {
+						needsWorktreeSwitch = selectedDir
+					}
+				}
+			}
 			current.SetFocused(false)
 		}
+
 		m.activePlugin = idx
+
+		if needsWorktreeSwitch != "" {
+			// Switch worktree context (triggers full reinit of all plugins).
+			// switchWorktree/switchProject modifies m synchronously, then returns
+			// async start commands. After the switch, re-focus the intended target.
+			targetPluginID := plugins[idx].ID()
+			switchCmd := m.switchWorktree(needsWorktreeSwitch)
+			// switchProject may have restored a different active plugin — override it.
+			m.FocusPluginByID(targetPluginID)
+			return switchCmd
+		}
+
 		// Focus new
 		if next := m.ActivePlugin(); next != nil {
 			next.SetFocused(true)

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -25,6 +25,17 @@ type TextInputConsumer interface {
 	ConsumesTextInput() bool
 }
 
+// WorkspaceContextProvider is an optional capability for plugins that manage
+// workspace/worktree selection. When the user navigates away from such a plugin,
+// the app layer checks if the selected workspace differs from the current WorkDir
+// and switches context accordingly. This ensures that other plugins (e.g., git status)
+// show the state of the workspace the user was just looking at.
+type WorkspaceContextProvider interface {
+	// SelectedWorkDir returns the absolute path of the currently selected workspace,
+	// or empty string if no workspace is selected or the selection matches the current context.
+	SelectedWorkDir() string
+}
+
 // Category represents a logical grouping of commands for the command palette.
 type Category string
 

--- a/internal/plugins/workspace/plugin.go
+++ b/internal/plugins/workspace/plugin.go
@@ -13,9 +13,9 @@ import (
 	"github.com/marcus/sidecar/internal/modal"
 	"github.com/marcus/sidecar/internal/mouse"
 	"github.com/marcus/sidecar/internal/plugin"
-	"github.com/marcus/sidecar/internal/ui"
 	"github.com/marcus/sidecar/internal/plugins/gitstatus"
 	"github.com/marcus/sidecar/internal/state"
+	"github.com/marcus/sidecar/internal/ui"
 )
 
 const (
@@ -34,11 +34,11 @@ const (
 	flashDuration = 1500 * time.Millisecond
 
 	// Hit region IDs
-	regionSidebar            = "sidebar"
-	regionPreviewPane        = "preview-pane"
-	regionPaneDivider        = "pane-divider"
-	regionWorktreeItem       = "workspace-item"
-	regionPreviewTab         = "preview-tab"
+	regionSidebar      = "sidebar"
+	regionPreviewPane  = "preview-pane"
+	regionPaneDivider  = "pane-divider"
+	regionWorktreeItem = "workspace-item"
+	regionPreviewTab   = "preview-tab"
 	// Agent choice modal IDs (modal library)
 	agentChoiceListID    = "agent-choice-list"
 	agentChoiceConfirmID = "agent-choice-confirm"
@@ -90,9 +90,9 @@ const (
 	typeSelectorInputID      = "type-selector-name-input"
 	typeSelectorConfirmID    = "type-selector-confirm"
 	typeSelectorCancelID     = "type-selector-cancel"
-	typeSelectorAgentListID  = "type-selector-agent-list"  // td-a902fe
-	typeSelectorSkipPermsID  = "type-selector-skip-perms"  // td-a902fe
-	typeSelectorAgentItemPfx = "ts-agent-"                 // td-a902fe: prefix for agent items
+	typeSelectorAgentListID  = "type-selector-agent-list" // td-a902fe
+	typeSelectorSkipPermsID  = "type-selector-skip-perms" // td-a902fe
+	typeSelectorAgentItemPfx = "ts-agent-"                // td-a902fe: prefix for agent items
 
 	// Shell delete confirmation modal regions
 )
@@ -113,20 +113,20 @@ type Plugin struct {
 	managedSessions map[string]bool
 
 	// View state
-	viewMode         ViewMode
-	activePane       FocusPane
-	previewTab       PreviewTab
-	selectedIdx      int
-	scrollOffset     int // Sidebar list scroll offset
-	visibleCount     int // Number of visible list items
+	viewMode            ViewMode
+	activePane          FocusPane
+	previewTab          PreviewTab
+	selectedIdx         int
+	scrollOffset        int // Sidebar list scroll offset
+	visibleCount        int // Number of visible list items
 	previewOffset       int
-	autoScrollOutput    bool // Auto-scroll output to follow agent (paused when user scrolls up)
-	scrollBaseLineCount int  // Snapshot of lineCount when scroll started (td-f7c8be: prevents bounce on poll)
-	sidebarWidth     int       // Persisted sidebar width
-	sidebarVisible   bool      // Whether sidebar is visible (toggled with \)
-	flashPreviewTime time.Time // When preview flash was triggered
-	toastMessage     string    // Temporary toast message to display
-	toastTime        time.Time // When toast was triggered
+	autoScrollOutput    bool      // Auto-scroll output to follow agent (paused when user scrolls up)
+	scrollBaseLineCount int       // Snapshot of lineCount when scroll started (td-f7c8be: prevents bounce on poll)
+	sidebarWidth        int       // Persisted sidebar width
+	sidebarVisible      bool      // Whether sidebar is visible (toggled with \)
+	flashPreviewTime    time.Time // When preview flash was triggered
+	toastMessage        string    // Temporary toast message to display
+	toastTime           time.Time // When toast was triggered
 
 	// Interactive selection state (preview pane)
 	selection                     ui.SelectionState
@@ -228,21 +228,21 @@ type Plugin struct {
 
 	// Merge workflow state
 	mergeState      *MergeWorkflowState
-	mergeModal      *modal.Modal // Modal instance for merge workflow
-	mergeModalWidth int          // Cached width for rebuild detection
+	mergeModal      *modal.Modal      // Modal instance for merge workflow
+	mergeModalWidth int               // Cached width for rebuild detection
 	mergeModalStep  MergeWorkflowStep // Cached step for rebuild detection
 
 	// Commit-before-merge state
-	mergeCommitState        *MergeCommitState
-	mergeCommitMessageInput textinput.Model
-	commitForMergeModal     *modal.Modal // Modal instance
-	commitForMergeModalWidth int         // Cached width for rebuild detection
+	mergeCommitState         *MergeCommitState
+	mergeCommitMessageInput  textinput.Model
+	commitForMergeModal      *modal.Modal // Modal instance
+	commitForMergeModalWidth int          // Cached width for rebuild detection
 
 	// Agent choice modal state (attach vs restart)
-	agentChoiceWorktree    *Worktree
-	agentChoiceIdx         int          // 0=attach, 1=restart
-	agentChoiceModal       *modal.Modal // Modal instance
-	agentChoiceModalWidth  int          // Cached width for rebuild detection
+	agentChoiceWorktree   *Worktree
+	agentChoiceIdx        int          // 0=attach, 1=restart
+	agentChoiceModal      *modal.Modal // Modal instance
+	agentChoiceModalWidth int          // Cached width for rebuild detection
 
 	// Delete confirmation modal state
 	deleteConfirmWorktree   *Worktree // Worktree pending deletion
@@ -290,10 +290,10 @@ type Plugin struct {
 	shellSelected    bool            // True when any shell is selected (vs a worktree)
 
 	// Type selector modal state (shell vs worktree)
-	typeSelectorIdx         int             // 0=Shell, 1=Worktree
-	typeSelectorNameInput   textinput.Model // Optional shell name input
-	typeSelectorModal       *modal.Modal    // Modal instance
-	typeSelectorModalWidth  int             // Cached width for rebuild detection
+	typeSelectorIdx        int             // 0=Shell, 1=Worktree
+	typeSelectorNameInput  textinput.Model // Optional shell name input
+	typeSelectorModal      *modal.Modal    // Modal instance
+	typeSelectorModalWidth int             // Cached width for rebuild detection
 
 	// Type selector modal - shell agent selection (td-2bb232)
 	typeSelectorAgentIdx   int       // Selected index in agent list (0 = None)
@@ -301,7 +301,7 @@ type Plugin struct {
 	typeSelectorSkipPerms  bool      // Whether skip permissions is checked
 	typeSelectorFocusField int       // Focus: 0=name, 1=agent, 2=skipPerms, 3=buttons
 
-// Resume conversation state (td-aa4136)
+	// Resume conversation state (td-aa4136)
 	pendingResumeCmd      string // Resume command to inject after shell creation
 	pendingResumeWorktree string // Worktree name to enter interactive mode after agent starts
 
@@ -606,6 +606,19 @@ func (p *Plugin) selectedWorktree() *Worktree {
 	return p.worktrees[p.selectedIdx]
 }
 
+// SelectedWorkDir implements plugin.WorkspaceContextProvider.
+// Returns the path of the currently selected worktree, or empty string if
+// no worktree is selected. Always returns the path even for the main worktree,
+// so the caller can detect when the user has switched back to main from a
+// feature worktree (where WorkDir still points to the feature worktree).
+func (p *Plugin) SelectedWorkDir() string {
+	wt := p.selectedWorktree()
+	if wt == nil {
+		return ""
+	}
+	return wt.Path
+}
+
 // outputVisibleFor returns true when a worktree's output is on-screen AND plugin is focused.
 func (p *Plugin) outputVisibleFor(worktreeName string) bool {
 	if !p.focused {
@@ -893,7 +906,7 @@ func (p *Plugin) moveCursor(delta int) {
 		p.previewOffset = 0
 		p.autoScrollOutput = true
 		p.resetScrollBaseLineCount() // td-f7c8be: clear snapshot for new selection
-		p.taskLoading = false // Reset task loading state for new selection (td-3668584f)
+		p.taskLoading = false        // Reset task loading state for new selection (td-3668584f)
 		// Exit interactive mode when switching selection (td-fc758e88)
 		p.exitInteractiveMode()
 		// Persist selection to disk
@@ -930,7 +943,7 @@ func (p *Plugin) cyclePreviewTab(delta int) tea.Cmd {
 	prevTab := p.previewTab
 	p.previewTab = PreviewTab((int(p.previewTab) + delta + 3) % 3)
 	p.previewOffset = 0
-	p.autoScrollOutput = true // Reset auto-scroll when switching tabs
+	p.autoScrollOutput = true    // Reset auto-scroll when switching tabs
 	p.resetScrollBaseLineCount() // td-f7c8be: clear snapshot when switching tabs
 
 	if prevTab == PreviewTabOutput && p.previewTab != PreviewTabOutput {

--- a/internal/plugins/workspace/selected_workdir_test.go
+++ b/internal/plugins/workspace/selected_workdir_test.go
@@ -1,0 +1,47 @@
+package workspace
+
+import (
+	"testing"
+)
+
+func TestSelectedWorkDir_ReturnsMainWorktreePath(t *testing.T) {
+	// SelectedWorkDir should return the path even for the main worktree,
+	// so that switching back to main from a feature worktree works correctly.
+	// See: https://github.com/marcus/sidecar/issues/143
+	p := &Plugin{
+		worktrees: []*Worktree{
+			{Name: "main", Path: "/repo", IsMain: true},
+			{Name: "feature", Path: "/repo-feature", IsMain: false},
+		},
+		selectedIdx: 0, // main selected
+	}
+
+	got := p.SelectedWorkDir()
+	if got != "/repo" {
+		t.Errorf("SelectedWorkDir() with main selected = %q, want %q", got, "/repo")
+	}
+}
+
+func TestSelectedWorkDir_ReturnsFeatureWorktreePath(t *testing.T) {
+	p := &Plugin{
+		worktrees: []*Worktree{
+			{Name: "main", Path: "/repo", IsMain: true},
+			{Name: "feature", Path: "/repo-feature", IsMain: false},
+		},
+		selectedIdx: 1, // feature selected
+	}
+
+	got := p.SelectedWorkDir()
+	if got != "/repo-feature" {
+		t.Errorf("SelectedWorkDir() with feature selected = %q, want %q", got, "/repo-feature")
+	}
+}
+
+func TestSelectedWorkDir_ReturnsEmptyWhenNoWorktrees(t *testing.T) {
+	p := &Plugin{}
+
+	got := p.SelectedWorkDir()
+	if got != "" {
+		t.Errorf("SelectedWorkDir() with no worktrees = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #143 — Git plugin doesn't track selected workspace.

When navigating away from the workspace plugin to another tab (e.g., git), the app now checks if the workspace plugin has a different worktree selected and triggers a full context switch. This ensures the git plugin (branch, status, diff, commits) reflects the worktree the user was just looking at.

## Changes

- **`internal/plugin/plugin.go`**: Added `WorkspaceContextProvider` interface — optional capability for plugins that manage workspace/worktree selection
- **`internal/plugins/workspace/plugin.go`**: Implemented `SelectedWorkDir()` on workspace plugin, returning the selected worktree path (including main worktree, fixing switch-back-to-main)
- **`internal/app/model.go`**: `SetActivePlugin()` now checks if the leaving plugin implements `WorkspaceContextProvider` and triggers `switchWorktree()` when the selected workspace differs from current `WorkDir`
- **`internal/plugins/workspace/selected_workdir_test.go`**: Unit tests for `SelectedWorkDir()`

## How it works

1. User is on workspace plugin, selects worktree `feature-x`
2. User clicks git tab (or any other plugin tab)
3. `SetActivePlugin` detects workspace plugin implements `WorkspaceContextProvider`
4. Calls `SelectedWorkDir()` → returns `/path/to/feature-x`
5. Compares with current `WorkDir` — they differ
6. Triggers `switchWorktree()` → `switchProject()` → `Registry.Reinit()`
7. All plugins (including git) reinitialize with the new worktree context

## Bug fix detail

The previous (stashed) implementation returned empty string for the main worktree (`IsMain` check), which meant switching **back** to main from a feature worktree was silently skipped. Fixed by always returning the path and letting the caller's normalization comparison handle the no-op case.

## Testing

- `go test ./...` — all pass
- Unit tests cover: main worktree selected, feature worktree selected, no worktrees