### PR TITLE
fix(workspace): use persisted agent type when reconnecting tmux sessions

### DIFF
--- a/internal/plugins/workspace/agent.go
+++ b/internal/plugins/workspace/agent.go
@@ -1429,8 +1429,12 @@ func (p *Plugin) reconnectAgents() tea.Cmd {
 
 			// Create agent record
 			paneID := getPaneID(session)
+			agentType := wt.ChosenAgentType
+			if agentType == "" || agentType == AgentNone {
+				agentType = AgentClaude // Fallback if no .sidecar-agent file
+			}
 			agent := &Agent{
-				Type:        AgentClaude, // Default, will be detected from output
+				Type:        agentType,
 				TmuxSession: session,
 				TmuxPane:    paneID,     // Capture pane ID for interactive mode
 				StartedAt:   time.Now(), // Unknown actual start


### PR DESCRIPTION
## Problem

`reconnectAgents()` hardcodes `AgentClaude` for every reconnected tmux session, ignoring the `.sidecar-agent` file persisted in each worktree. This causes non-Claude agents (Copilot, Codex, Gemini, etc.) to display as "claude" in the workspace sidebar after restarting sidecar.

## Fix

Read `wt.ChosenAgentType` (already loaded from `.sidecar-agent` at startup) when creating the agent record during reconnection. Falls back to `AgentClaude` only when no agent type was persisted.

## Testing

1. Launch a worktree with a non-Claude agent (e.g. Copilot)
2. Exit and restart sidecar
3. Verify the workspace sidebar shows the correct agent name instead of "claude"