### PR TITLE
feat: harden tdmonitor trifecta WO middleware integration

### DIFF
--- a/cmd/sidecar/main.go
+++ b/cmd/sidecar/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/marcus/sidecar/internal/plugins/gitstatus"
 	"github.com/marcus/sidecar/internal/plugins/notes"
 	"github.com/marcus/sidecar/internal/plugins/tdmonitor"
+	"github.com/marcus/sidecar/internal/plugins/trifecta"
 	"github.com/marcus/sidecar/internal/plugins/workspace"
 	"github.com/marcus/sidecar/internal/state"
 	"github.com/marcus/sidecar/internal/styles"
@@ -188,6 +189,10 @@ func main() {
 		if err := registry.Register(notes.New()); err != nil {
 			logger.Warn("failed to register notes plugin", "err", err)
 		}
+	}
+	// Register Trifecta plugin
+	if err := registry.Register(trifecta.New()); err != nil {
+		logger.Warn("failed to register trifecta plugin", "err", err)
 	}
 
 	// Apply user keymap overrides

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/marcus/td v0.33.0
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/mattn/go-sqlite3 v1.14.33
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/term v0.39.0
 	modernc.org/sqlite v1.41.0
 )
@@ -37,6 +38,7 @@ require (
 	github.com/clipperhouse/displaywidth v0.6.2 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
@@ -55,6 +57,7 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/soniakeys/quant v1.0.0 // indirect
@@ -66,6 +69,7 @@ require (
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.66.10 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,7 @@ golang.org/x/text v0.33.0 h1:B3njUFyqtHDUI5jMn1YIr5B0IE2U0qck04r6d4KPAxE=
 golang.org/x/text v0.33.0/go.mod h1:LuMebE6+rBincTi9+xWTY8TztLzKHc/9C1uBCG27+q8=
 golang.org/x/tools v0.40.0 h1:yLkxfA+Qnul4cs9QA3KnlFu0lVmd8JJfoq+E41uSutA=
 golang.org/x/tools v0.40.0/go.mod h1:Ik/tzLRlbscWpqqMRjyWYDisX8bG13FrdXp3o4Sr9lc=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/plugins/tdmonitor/trifecta_overlay_test.go
+++ b/internal/plugins/tdmonitor/trifecta_overlay_test.go
@@ -1,0 +1,160 @@
+package tdmonitor
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/marcus/sidecar/internal/plugin"
+	"github.com/marcus/sidecar/internal/trifectaindex"
+)
+
+func TestWOOverlayIndexMissing(t *testing.T) {
+	p := newOverlayPlugin(t.TempDir())
+	p.refreshWOOverlay()
+	if p.woStateCode == "" {
+		t.Fatalf("expected missing index state code")
+	}
+	if got := p.renderWOOverlay(120); !strings.Contains(got, "INDEX_MISSING") {
+		t.Fatalf("expected INDEX_MISSING in overlay, got %q", got)
+	}
+}
+
+func TestWOOverlayInvalidJSON(t *testing.T) {
+	root := t.TempDir()
+	writeIndexFile(t, root, "{bad-json")
+
+	p := newOverlayPlugin(root)
+	p.refreshWOOverlay()
+	if p.woStateCode != "INDEX_INVALID_JSON" {
+		t.Fatalf("expected INDEX_INVALID_JSON, got %s", p.woStateCode)
+	}
+}
+
+func TestWOOverlaySchemaUnsupported(t *testing.T) {
+	root := t.TempDir()
+	writeIndexFile(t, root, `{"version":1,"schema":"wrong","generated_at":"2026-02-12T10:00:00Z","repo_root":"`+root+`","git_head_sha_repo_root":"abc","work_orders":[],"errors":[]}`)
+
+	p := newOverlayPlugin(root)
+	p.refreshWOOverlay()
+	if p.woStateCode != "INDEX_SCHEMA_UNSUPPORTED" {
+		t.Fatalf("expected INDEX_SCHEMA_UNSUPPORTED, got %s", p.woStateCode)
+	}
+}
+
+func TestWOOverlayRepoMismatch(t *testing.T) {
+	root := t.TempDir()
+	writeIndexFile(t, root, `{"version":1,"schema":"trifecta.sidecar.wo_index.v1","generated_at":"2026-02-12T10:00:00Z","repo_root":"/tmp/another-repo","git_head_sha_repo_root":"abc","work_orders":[],"errors":[]}`)
+
+	p := newOverlayPlugin(root)
+	p.refreshWOOverlay()
+	if p.woStateCode != "INDEX_REPO_MISMATCH" {
+		t.Fatalf("expected INDEX_REPO_MISMATCH, got %s", p.woStateCode)
+	}
+}
+
+func TestWOOverlaySingleAndMultipleRunning(t *testing.T) {
+	root := t.TempDir()
+	writeIndexFile(t, root, `{
+  "version": 1,
+  "schema": "trifecta.sidecar.wo_index.v1",
+  "generated_at": "2026-02-12T10:00:00Z",
+  "repo_root": "`+root+`",
+  "git_head_sha_repo_root": "abc",
+  "work_orders": [
+    {"id":"WO-001","title":"A","status":"running","priority":"P1","owner":"u1","epic_id":"","worktree_path":"../.worktrees/WO-001","worktree_exists":true,"branch":"","wo_yaml_path":"_ctx/jobs/running/WO-001.yaml","created_at":"2026-02-12T09:00:00Z"},
+    {"id":"WO-002","title":"B","status":"running","priority":"P2","owner":"u2","epic_id":"","worktree_path":"../.worktrees/WO-002","worktree_exists":true,"branch":"","wo_yaml_path":"_ctx/jobs/running/WO-002.yaml","created_at":"2026-02-12T08:00:00Z"}
+  ],
+  "errors": []
+}`)
+
+	p := newOverlayPlugin(root)
+	p.refreshWOOverlay()
+	if p.woActive == nil {
+		t.Fatalf("expected active WO")
+	}
+	got := p.renderWOOverlay(120)
+	if !strings.Contains(got, "WO [WO-001]") {
+		t.Fatalf("expected WO-001 active in overlay, got %q", got)
+	}
+	if !strings.Contains(got, "(+1)") {
+		t.Fatalf("expected +1 in overlay, got %q", got)
+	}
+}
+
+func TestWOOverlayPollMtimeBehavior(t *testing.T) {
+	root := t.TempDir()
+	indexPath := writeIndexFile(t, root, `{"version":1,"schema":"trifecta.sidecar.wo_index.v1","generated_at":"2026-02-12T10:00:00Z","repo_root":"`+root+`","git_head_sha_repo_root":"abc","work_orders":[{"id":"WO-001","title":"A","status":"running","priority":"P1","owner":"","epic_id":"","worktree_path":"../.worktrees/WO-001","worktree_exists":true,"branch":"","wo_yaml_path":"_ctx/jobs/running/WO-001.yaml","created_at":"2026-02-12T09:00:00Z"}],"errors":[]}`)
+
+	p := newOverlayPlugin(root)
+	p.refreshWOOverlay()
+	firstMtime := p.woIndexMTime
+	firstID := p.woActive.ID
+
+	// same mtime => cached result reused
+	p.refreshWOOverlay()
+	if !p.woIndexMTime.Equal(firstMtime) {
+		t.Fatalf("expected mtime unchanged")
+	}
+	if p.woActive.ID != firstID {
+		t.Fatalf("expected same active WO when mtime unchanged")
+	}
+
+	// update file and mtime => reload must happen
+	time.Sleep(1100 * time.Millisecond)
+	if err := os.WriteFile(indexPath, []byte(`{"version":1,"schema":"trifecta.sidecar.wo_index.v1","generated_at":"2026-02-12T10:00:10Z","repo_root":"`+root+`","git_head_sha_repo_root":"abc","work_orders":[{"id":"WO-009","title":"Z","status":"running","priority":"P0","owner":"","epic_id":"","worktree_path":"../.worktrees/WO-009","worktree_exists":true,"branch":"","wo_yaml_path":"_ctx/jobs/running/WO-009.yaml","created_at":"2026-02-12T10:00:10Z"}],"errors":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p.refreshWOOverlay()
+	if p.woActive == nil || p.woActive.ID != "WO-009" {
+		t.Fatalf("expected active WO to reload as WO-009, got %+v", p.woActive)
+	}
+}
+
+func TestInjectWOInCurrentWorkReplacesNoCurrentWork(t *testing.T) {
+	p := &Plugin{
+		woActive: &trifectaindex.WorkOrder{
+			ID:           "WO-0010",
+			Status:       "running",
+			Priority:     "P2",
+			Owner:        "felipe_gonzalez",
+			WorktreePath: "../.worktrees/WO-0010",
+		},
+		woExtra: 0,
+	}
+
+	input := "CURRENT WORK\nNo current work\n\nBOARD: All Issues"
+	got := p.injectWOInCurrentWork(input)
+
+	if strings.Contains(got, "No current work") {
+		t.Fatalf("expected 'No current work' to be replaced, got %q", got)
+	}
+	if !strings.Contains(got, "WO [WO-0010]") {
+		t.Fatalf("expected WO line inside CURRENT WORK, got %q", got)
+	}
+}
+
+func newOverlayPlugin(root string) *Plugin {
+	return &Plugin{
+		ctx: &plugin.Context{
+			WorkDir: root,
+			Logger:  slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		},
+	}
+}
+
+func writeIndexFile(t *testing.T, root, content string) string {
+	t.Helper()
+	indexDir := filepath.Join(root, "_ctx", "index")
+	if err := os.MkdirAll(indexDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	indexPath := filepath.Join(indexDir, "wo_worktrees.json")
+	if err := os.WriteFile(indexPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return indexPath
+}

--- a/internal/plugins/trifecta/plugin.go
+++ b/internal/plugins/trifecta/plugin.go
@@ -1,0 +1,265 @@
+package trifecta
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/marcus/sidecar/internal/plugin"
+	"github.com/marcus/sidecar/internal/trifectaindex"
+)
+
+const (
+	pluginID   = "trifecta"
+	pluginName = "Trifecta"
+	pluginIcon = "T"
+)
+
+// Plugin implements plugin.Plugin interface
+type Plugin struct {
+	ctx     *plugin.Context
+	focused bool
+	width   int
+	height  int
+
+	// Data
+	index       *trifectaindex.WOIndex
+	indexLoaded bool
+	lastError   string
+	lastLoad    time.Time
+
+	// View state
+	cursor       int
+	filterStatus trifectaindex.WOStatus
+}
+
+func New() *Plugin {
+	return &Plugin{
+		filterStatus: trifectaindex.WOStatus(""), // No filter
+	}
+}
+
+// plugin.Plugin interface
+func (p *Plugin) ID() string   { return pluginID }
+func (p *Plugin) Name() string { return pluginName }
+func (p *Plugin) Icon() string { return pluginIcon }
+
+func (p *Plugin) Init(ctx *plugin.Context) error {
+	p.ctx = ctx
+	return p.loadIndex()
+}
+
+func (p *Plugin) Start() tea.Cmd {
+	return nil
+}
+
+// statusColorMap maps WO statuses to their display colors
+var statusColorMap = map[trifectaindex.WOStatus]lipgloss.Color{
+	trifectaindex.WOStatusRunning: lipgloss.Color("blue"),
+	trifectaindex.WOStatusDone:    lipgloss.Color("green"),
+	trifectaindex.WOStatusFailed:  lipgloss.Color("red"),
+	// Default: gray (used for pending)
+}
+
+func (p *Plugin) Stop() {}
+
+func (p *Plugin) Update(msg tea.Msg) (plugin.Plugin, tea.Cmd) {
+	switch m := msg.(type) {
+	case tea.KeyMsg:
+		return p, p.handleKey(m)
+	}
+	return p, nil
+}
+
+func (p *Plugin) View(width, height int) string {
+	p.width, p.height = width, height
+
+	if !p.indexLoaded {
+		return p.renderError()
+	}
+	return p.renderList()
+}
+
+func (p *Plugin) IsFocused() bool         { return p.focused }
+func (p *Plugin) SetFocused(focused bool) { p.focused = focused }
+
+// Commands returns available commands for command palette
+func (p *Plugin) Commands() []plugin.Command {
+	return nil // No custom commands for now
+}
+
+// FocusContext returns context string for focus indication
+func (p *Plugin) FocusContext() string {
+	return "Trifecta Work Orders"
+}
+
+func (p *Plugin) IndexFilePath() string {
+	return filepath.Join(p.ctx.WorkDir, "_ctx", "index", trifectaindex.IndexFilename)
+}
+
+func (p *Plugin) loadIndex() error {
+	path := p.IndexFilePath()
+	index, err := trifectaindex.LoadAndValidate(path, p.ctx.WorkDir)
+	if err != nil {
+		p.lastError = fmt.Sprintf("%v", err)
+		return err
+	}
+
+	p.index = index
+	p.indexLoaded = true
+	p.lastError = ""
+	p.lastLoad = time.Now()
+
+	// Reset cursor if out of bounds
+	p.resetCursor()
+	return nil
+}
+
+func (p *Plugin) filteredWorkOrders() []trifectaindex.WorkOrder {
+	if p.index == nil {
+		return nil
+	}
+
+	var filtered []trifectaindex.WorkOrder
+	for _, wo := range p.index.WorkOrders {
+		if p.filterStatus == "" || wo.Status == p.filterStatus {
+			filtered = append(filtered, wo)
+		}
+	}
+	return filtered
+}
+
+func (p *Plugin) resetCursor() {
+	filtered := p.filteredWorkOrders()
+	if p.cursor >= len(filtered) {
+		p.cursor = len(filtered) - 1
+	}
+	if p.cursor < 0 {
+		p.cursor = 0
+	}
+}
+
+func (p *Plugin) selectedWorkOrder() *trifectaindex.WorkOrder {
+	filtered := p.filteredWorkOrders()
+	if p.cursor >= 0 && p.cursor < len(filtered) {
+		return &filtered[p.cursor]
+	}
+	return nil
+}
+
+// Keybindings (sin colisiones)
+func (p *Plugin) handleKey(msg tea.KeyMsg) tea.Cmd {
+	switch msg.String() {
+	case "q", "esc":
+		return tea.Quit
+
+	case "up", "k":
+		if p.cursor > 0 {
+			p.cursor--
+		}
+	case "down", "j":
+		filtered := p.filteredWorkOrders()
+		if p.cursor < len(filtered)-1 {
+			p.cursor++
+		}
+
+	case "p": // Filter pending
+		p.filterStatus = trifectaindex.WOStatusPending
+		p.cursor = 0
+	case "r": // Filter running (lowercase r)
+		p.filterStatus = trifectaindex.WOStatusRunning
+		p.cursor = 0
+	case "R": // Refresh (uppercase R = Shift+r)
+		_ = p.loadIndex()
+	case "d": // Filter done
+		p.filterStatus = trifectaindex.WOStatusDone
+		p.cursor = 0
+	case "f": // Filter failed
+		p.filterStatus = trifectaindex.WOStatusFailed
+		p.cursor = 0
+	case "a": // All
+		p.filterStatus = trifectaindex.WOStatus("")
+		p.cursor = 0
+
+	case "o": // Open YAML in editor
+		return p.handleOpenYAML()
+	}
+
+	return nil
+}
+
+func (p *Plugin) handleOpenYAML() tea.Cmd {
+	wo := p.selectedWorkOrder()
+	if wo == nil {
+		return nil
+	}
+
+	yamlAbs := filepath.Join(p.ctx.WorkDir, wo.WOYAMLPath)
+	if _, err := os.Stat(yamlAbs); os.IsNotExist(err) {
+		p.lastError = fmt.Sprintf("YAML not found: %s", wo.WOYAMLPath)
+		return nil
+	}
+
+	// TODO: Import enterInlineEditMode from filebrowser for real tmux editor
+	// Current implementation just logs/shows YAML path
+	p.lastError = fmt.Sprintf("Opening YAML: %s", yamlAbs)
+	return nil
+}
+
+func (p *Plugin) renderList() string {
+	filtered := p.filteredWorkOrders()
+
+	var sb strings.Builder
+	sb.WriteString(lipgloss.NewStyle().Bold(true).Render("Trifecta Work Orders"))
+	sb.WriteString("\n\n")
+
+	if len(filtered) == 0 {
+		sb.WriteString("No work orders found.")
+		return sb.String()
+	}
+
+	for i, wo := range filtered {
+		cursor := " "
+		if i == p.cursor {
+			cursor = ">"
+		}
+
+		// Get status color from map (default to gray if not found)
+		statusColor, ok := statusColorMap[wo.Status]
+		if !ok {
+			statusColor = lipgloss.Color("gray")
+		}
+
+		line := fmt.Sprintf("%s [%s] %s %s\n",
+			cursor,
+			lipgloss.NewStyle().Foreground(statusColor).Render(string(wo.Status)),
+			wo.ID,
+			wo.Title,
+		)
+		sb.WriteString(line)
+	}
+
+	// Footer
+	if p.filterStatus != "" {
+		sb.WriteString(fmt.Sprintf("\nFilter: %s (a=clear)", p.filterStatus))
+	}
+	if !p.lastLoad.IsZero() {
+		sb.WriteString(fmt.Sprintf("\nLast update: %s", p.lastLoad.Format("15:04:05")))
+	}
+	sb.WriteString("\n\nKeys: R=refresh, r=running, o=show YAML path, p/d/f=filter")
+
+	return sb.String()
+}
+
+func (p *Plugin) renderError() string {
+	var sb strings.Builder
+	sb.WriteString("Trifecta Work Orders\n\n")
+	sb.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("red")).Render("Error: "))
+	sb.WriteString(p.lastError)
+	sb.WriteString("\n\nPress 'R' to retry loading index")
+	return sb.String()
+}

--- a/internal/plugins/trifecta/plugin_test.go
+++ b/internal/plugins/trifecta/plugin_test.go
@@ -1,0 +1,195 @@
+package trifecta
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/marcus/sidecar/internal/plugin"
+	"github.com/marcus/sidecar/internal/trifectaindex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleKey_FilterTransitions tests T10: keybindings for filter state transitions
+func TestHandleKey_FilterTransitions(t *testing.T) {
+	tests := []struct {
+		key        string
+		wantStatus trifectaindex.WOStatus
+	}{
+		{"p", trifectaindex.WOStatusPending},
+		{"r", trifectaindex.WOStatusRunning},
+		{"d", trifectaindex.WOStatusDone},
+		{"f", trifectaindex.WOStatusFailed},
+		{"a", trifectaindex.WOStatus("")}, // Clear filter
+	}
+
+	for _, tt := range tests {
+		t.Run("key "+tt.key, func(t *testing.T) {
+			p := New()
+			p.indexLoaded = true
+
+			p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(tt.key)})
+			assert.Equal(t, tt.wantStatus, p.filterStatus, "filterStatus should match expected for key "+tt.key)
+		})
+	}
+}
+
+// TestHandleKey_CursorMovement tests T10: cursor movement keys
+func TestHandleKey_CursorMovement(t *testing.T) {
+	p := New()
+	p.indexLoaded = true
+	p.index = &trifectaindex.WOIndex{
+		WorkOrders: []trifectaindex.WorkOrder{
+			{ID: "WO-0001", Title: "First", Status: trifectaindex.WOStatusPending},
+			{ID: "WO-0002", Title: "Second", Status: trifectaindex.WOStatusPending},
+			{ID: "WO-0003", Title: "Third", Status: trifectaindex.WOStatusPending},
+		},
+	}
+
+	t.Run("down/j moves cursor down", func(t *testing.T) {
+		initialCursor := p.cursor
+		p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+		assert.Equal(t, initialCursor+1, p.cursor, "j should move cursor down")
+
+		p.Update(tea.KeyMsg{Type: tea.KeyDown})
+		assert.Equal(t, initialCursor+2, p.cursor, "down arrow should move cursor down")
+	})
+
+	t.Run("up/k moves cursor up", func(t *testing.T) {
+		p.cursor = 2
+		p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+		assert.Equal(t, 1, p.cursor, "k should move cursor up")
+
+		p.Update(tea.KeyMsg{Type: tea.KeyUp})
+		assert.Equal(t, 0, p.cursor, "up arrow should move cursor up")
+	})
+
+	t.Run("cursor does not go below zero", func(t *testing.T) {
+		p.cursor = 0
+		p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+		assert.Equal(t, 0, p.cursor, "cursor should stay at 0")
+	})
+}
+
+// TestHandleKey_Quit tests T10: quit keybindings
+func TestHandleKey_Quit(t *testing.T) {
+	p := New()
+
+	t.Run("q quits", func(t *testing.T) {
+		_, cmd := p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+		require.NotNil(t, cmd, "q should return a command")
+		assert.Equal(t, tea.Quit(), cmd(), "q should return tea.Quit")
+	})
+
+	t.Run("esc quits", func(t *testing.T) {
+		_, cmd := p.Update(tea.KeyMsg{Type: tea.KeyEscape})
+		require.NotNil(t, cmd, "esc should return a command")
+		assert.Equal(t, tea.Quit(), cmd(), "esc should return tea.Quit")
+	})
+}
+
+// TestHandleKey_Refresh tests T10: refresh keybinding
+func TestHandleKey_Refresh(t *testing.T) {
+	p := New()
+	p.ctx = &plugin.Context{WorkDir: "/tmp"}
+	p.indexLoaded = true
+
+	// R (uppercase) triggers refresh - it calls loadIndex()
+	// Note: This will fail since /tmp doesn't have a valid index, but we're testing the keybinding
+	_, cmd := p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("R")})
+	// Refresh doesn't return a command, just reloads index
+	assert.Nil(t, cmd, "R should not return a command")
+}
+
+// TestHandleKey_OpenYAML tests T10: open YAML keybinding
+func TestHandleKey_OpenYAML(t *testing.T) {
+	p := New()
+	p.indexLoaded = true
+
+	// 'o' key triggers handleOpenYAML - returns nil if no work order selected
+	_, cmd := p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("o")})
+	assert.Nil(t, cmd, "o should return nil when no WO selected")
+}
+
+// TestLoadIndex_Integration tests T11: integration test for WO index loading
+func TestLoadIndex_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	realRepoPath := "/Users/felipe_gonzalez/Developer/agent_h/trifecta_dope"
+
+	t.Run("loads real index successfully", func(t *testing.T) {
+		p := New()
+		p.ctx = &plugin.Context{WorkDir: realRepoPath}
+
+		err := p.loadIndex()
+		require.NoError(t, err, "loadIndex should succeed for real repo")
+		assert.True(t, p.indexLoaded, "indexLoaded should be true after load")
+		assert.NotNil(t, p.index, "index should not be nil after load")
+	})
+
+	t.Run("work orders have required fields", func(t *testing.T) {
+		p := New()
+		p.ctx = &plugin.Context{WorkDir: realRepoPath}
+		err := p.loadIndex()
+		require.NoError(t, err)
+
+		for _, wo := range p.index.WorkOrders {
+			assert.NotEmpty(t, wo.ID, "WO ID should not be empty")
+			assert.NotEmpty(t, wo.Title, "WO Title should not be empty")
+			assert.NotEmpty(t, wo.Status, "WO Status should not be empty")
+		}
+	})
+
+	t.Run("returns error for nonexistent path", func(t *testing.T) {
+		p := New()
+		p.ctx = &plugin.Context{WorkDir: "/nonexistent/path/12345"}
+
+		err := p.loadIndex()
+		assert.Error(t, err, "loadIndex should return error for nonexistent path")
+		assert.False(t, p.indexLoaded, "indexLoaded should be false on error")
+	})
+}
+
+// TestLoadIndex_IndexFilePath tests the index file path construction
+func TestLoadIndex_IndexFilePath(t *testing.T) {
+	p := New()
+	p.ctx = &plugin.Context{WorkDir: "/tmp/test"}
+
+	expected := "/tmp/test/_ctx/index/wo_worktrees.json"
+	assert.Equal(t, expected, p.IndexFilePath(), "IndexFilePath should return correct path")
+}
+
+// TestFilteredWorkOrders tests the filter functionality
+func TestFilteredWorkOrders(t *testing.T) {
+	p := New()
+	p.index = &trifectaindex.WOIndex{
+		WorkOrders: []trifectaindex.WorkOrder{
+			{ID: "WO-0001", Title: "First", Status: trifectaindex.WOStatusPending},
+			{ID: "WO-0002", Title: "Second", Status: trifectaindex.WOStatusRunning},
+			{ID: "WO-0003", Title: "Third", Status: trifectaindex.WOStatusDone},
+			{ID: "WO-0004", Title: "Fourth", Status: trifectaindex.WOStatusFailed},
+		},
+	}
+	p.indexLoaded = true
+
+	tests := []struct {
+		filter    trifectaindex.WOStatus
+		wantCount int
+	}{
+		{trifectaindex.WOStatusPending, 1},
+		{trifectaindex.WOStatusRunning, 1},
+		{trifectaindex.WOStatusDone, 1},
+		{trifectaindex.WOStatusFailed, 1},
+		{trifectaindex.WOStatus(""), 4}, // No filter
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.filter), func(t *testing.T) {
+			p.filterStatus = tt.filter
+			filtered := p.filteredWorkOrders()
+			assert.Len(t, filtered, tt.wantCount, "filtered count should match expected")
+		})
+	}
+}

--- a/internal/trifectaindex/loader.go
+++ b/internal/trifectaindex/loader.go
@@ -1,0 +1,95 @@
+package trifectaindex
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type LoadErrorCode string
+
+const (
+	LoadErrorIndexMissing      LoadErrorCode = "INDEX_MISSING"
+	LoadErrorInvalidJSON       LoadErrorCode = "INDEX_INVALID_JSON"
+	LoadErrorSchemaUnsupported LoadErrorCode = "INDEX_SCHEMA_UNSUPPORTED"
+	LoadErrorRepoMismatch      LoadErrorCode = "INDEX_REPO_MISMATCH"
+	LoadErrorReadFailed        LoadErrorCode = "INDEX_READ_FAILED"
+)
+
+type LoadError struct {
+	Code LoadErrorCode
+	Path string
+	Err  error
+}
+
+func (e *LoadError) Error() string {
+	if e.Err == nil {
+		return string(e.Code)
+	}
+	return fmt.Sprintf("%s: %v", e.Code, e.Err)
+}
+
+func (e *LoadError) Unwrap() error { return e.Err }
+
+// LoadIndex reads and unmarshals a WOIndex from the given path
+func LoadIndex(path string) (*WOIndex, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, &LoadError{Code: LoadErrorIndexMissing, Path: path, Err: err}
+		}
+		return nil, &LoadError{Code: LoadErrorReadFailed, Path: path, Err: err}
+	}
+	var idx WOIndex
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return nil, &LoadError{Code: LoadErrorInvalidJSON, Path: path, Err: err}
+	}
+	return &idx, nil
+}
+
+// LoadAndValidate loads the index and verifies schema + repo scope.
+func LoadAndValidate(path string, expectedRepoRoot string) (*WOIndex, error) {
+	idx, err := LoadIndex(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := idx.Validate(); err != nil {
+		return nil, &LoadError{Code: LoadErrorSchemaUnsupported, Path: path, Err: err}
+	}
+	if expectedRepoRoot != "" {
+		idxRoot, err := canonicalPath(idx.RepoRoot)
+		if err != nil {
+			return nil, &LoadError{Code: LoadErrorRepoMismatch, Path: path, Err: err}
+		}
+		expected, err := canonicalPath(expectedRepoRoot)
+		if err != nil {
+			return nil, &LoadError{Code: LoadErrorRepoMismatch, Path: path, Err: err}
+		}
+		if idxRoot != expected {
+			return nil, &LoadError{
+				Code: LoadErrorRepoMismatch,
+				Path: path,
+				Err:  fmt.Errorf("index repo_root=%s expected=%s", idx.RepoRoot, expectedRepoRoot),
+			}
+		}
+	}
+	return idx, nil
+}
+
+func canonicalPath(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("abs path failed for %q: %w", path, err)
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		// fallback controlled: for non-existent paths, use cleaned absolute
+		if errors.Is(err, os.ErrNotExist) {
+			return filepath.Clean(abs), nil
+		}
+		return "", fmt.Errorf("eval symlinks failed for %q: %w", abs, err)
+	}
+	return filepath.Clean(resolved), nil
+}

--- a/internal/trifectaindex/loader_test.go
+++ b/internal/trifectaindex/loader_test.go
@@ -1,0 +1,173 @@
+package trifectaindex
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadAndValidate_MissingFile(t *testing.T) {
+	_, err := LoadAndValidate("/tmp/does-not-exist.json", "/tmp")
+	if err == nil {
+		t.Fatalf("expected error for missing file")
+	}
+	var loadErr *LoadError
+	if !errors.As(err, &loadErr) {
+		t.Fatalf("expected LoadError, got %T", err)
+	}
+	if loadErr.Code != LoadErrorIndexMissing {
+		t.Fatalf("expected %s, got %s", LoadErrorIndexMissing, loadErr.Code)
+	}
+}
+
+func TestLoadAndValidate_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wo_worktrees.json")
+	if err := os.WriteFile(path, []byte("{bad-json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadAndValidate(path, dir)
+	if err == nil {
+		t.Fatalf("expected invalid json error")
+	}
+	var loadErr *LoadError
+	if !errors.As(err, &loadErr) {
+		t.Fatalf("expected LoadError, got %T", err)
+	}
+	if loadErr.Code != LoadErrorInvalidJSON {
+		t.Fatalf("expected %s, got %s", LoadErrorInvalidJSON, loadErr.Code)
+	}
+}
+
+func TestLoadAndValidate_ValidIndex(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wo_worktrees.json")
+	content := `{
+  "version": 1,
+  "schema": "trifecta.sidecar.wo_index.v1",
+  "generated_at": "2026-02-12T10:00:00Z",
+  "repo_root": "` + dir + `",
+  "git_head_sha_repo_root": "abc",
+  "work_orders": [
+    {
+      "id": "WO-1",
+      "title": "t",
+      "status": "running",
+      "priority": "P1",
+      "owner": "",
+      "epic_id": "",
+      "worktree_path": "../.worktrees/WO-1",
+      "worktree_exists": true,
+      "branch": "feat/wo-WO-1",
+      "wo_yaml_path": "_ctx/jobs/running/WO-1.yaml",
+      "created_at": ""
+    }
+  ],
+  "errors": []
+}`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	idx, err := LoadAndValidate(path, dir)
+	if err != nil {
+		t.Fatalf("expected valid index, got error: %v", err)
+	}
+	if len(idx.WorkOrders) != 1 {
+		t.Fatalf("expected 1 work order, got %d", len(idx.WorkOrders))
+	}
+}
+
+func TestLoadAndValidate_AcceptsLegacySpaceSeparatedTimestamps(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wo_worktrees.json")
+	content := `{
+  "version": 1,
+  "schema": "trifecta.sidecar.wo_index.v1",
+  "generated_at": "2026-02-10 14:28:30+00:00",
+  "repo_root": "` + dir + `",
+  "git_head_sha_repo_root": "abc",
+  "work_orders": [
+    {
+      "id": "WO-1",
+      "title": "t",
+      "status": "running",
+      "priority": "P1",
+      "owner": "",
+      "epic_id": "",
+      "worktree_path": "../.worktrees/WO-1",
+      "worktree_exists": true,
+      "branch": "feat/wo-WO-1",
+      "wo_yaml_path": "_ctx/jobs/running/WO-1.yaml",
+      "created_at": "2026-02-10 14:28:30+00:00"
+    }
+  ],
+  "errors": []
+}`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadAndValidate(path, dir); err != nil {
+		t.Fatalf("expected legacy timestamp format to be accepted, got error: %v", err)
+	}
+}
+
+func TestLoadAndValidate_RepoMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wo_worktrees.json")
+	content := `{
+  "version": 1,
+  "schema": "trifecta.sidecar.wo_index.v1",
+  "generated_at": "2026-02-12T10:00:00Z",
+  "repo_root": "/tmp/another-repo",
+  "git_head_sha_repo_root": "abc",
+  "work_orders": [],
+  "errors": []
+}`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadAndValidate(path, dir)
+	if err == nil {
+		t.Fatalf("expected repo mismatch error")
+	}
+	var loadErr *LoadError
+	if !errors.As(err, &loadErr) {
+		t.Fatalf("expected LoadError, got %T", err)
+	}
+	if loadErr.Code != LoadErrorRepoMismatch {
+		t.Fatalf("expected %s, got %s", LoadErrorRepoMismatch, loadErr.Code)
+	}
+}
+
+func TestLoadAndValidate_RepoRootCanonicalSymlinkMatch(t *testing.T) {
+	dir := t.TempDir()
+	realRepo := filepath.Join(dir, "real-repo")
+	if err := os.MkdirAll(realRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	linkRepo := filepath.Join(dir, "repo-link")
+	if err := os.Symlink(realRepo, linkRepo); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+
+	indexPath := filepath.Join(realRepo, "wo_worktrees.json")
+	content := `{
+  "version": 1,
+  "schema": "trifecta.sidecar.wo_index.v1",
+  "generated_at": "2026-02-12T10:00:00Z",
+  "repo_root": "` + realRepo + `",
+  "git_head_sha_repo_root": "abc",
+  "work_orders": [],
+  "errors": []
+}`
+	if err := os.WriteFile(indexPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadAndValidate(indexPath, linkRepo)
+	if err != nil {
+		t.Fatalf("expected canonical symlink match, got error: %v", err)
+	}
+}

--- a/internal/trifectaindex/select_active.go
+++ b/internal/trifectaindex/select_active.go
@@ -1,0 +1,79 @@
+package trifectaindex
+
+import (
+	"slices"
+	"strings"
+	"time"
+)
+
+type ActiveWOSelection struct {
+	ActiveWO          *WorkOrder
+	RunningCount      int
+	ExtraRunningCount int
+	Reason            string
+}
+
+// SelectActiveWorkOrder picks one running WO deterministically:
+// priority desc -> recency desc -> id asc.
+func SelectActiveWorkOrder(workOrders []WorkOrder) ActiveWOSelection {
+	running := make([]WorkOrder, 0)
+	for _, wo := range workOrders {
+		if wo.Status == WOStatusRunning {
+			running = append(running, wo)
+		}
+	}
+
+	selection := ActiveWOSelection{
+		RunningCount:      len(running),
+		ExtraRunningCount: max(len(running)-1, 0),
+	}
+	if len(running) == 0 {
+		selection.Reason = "no_running_work_orders"
+		return selection
+	}
+
+	slices.SortFunc(running, func(a, b WorkOrder) int {
+		pa, pb := priorityScore(a.Priority), priorityScore(b.Priority)
+		if pa != pb {
+			return pb - pa
+		}
+		ta, tb := recency(a), recency(b)
+		if !ta.Equal(tb) {
+			if ta.After(tb) {
+				return -1
+			}
+			return 1
+		}
+		return strings.Compare(a.ID, b.ID)
+	})
+
+	active := running[0]
+	selection.ActiveWO = &active
+	selection.Reason = "priority_then_recency_then_id"
+	return selection
+}
+
+func priorityScore(priority string) int {
+	switch strings.ToLower(strings.TrimSpace(priority)) {
+	case "p0", "critical":
+		return 4
+	case "p1", "high":
+		return 3
+	case "p2", "medium":
+		return 2
+	case "p3", "low":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func recency(wo WorkOrder) time.Time {
+	if !wo.CreatedAt.IsZero() {
+		return wo.CreatedAt
+	}
+	if !wo.ClosedAt.IsZero() {
+		return wo.ClosedAt
+	}
+	return time.Time{}
+}

--- a/internal/trifectaindex/select_active_test.go
+++ b/internal/trifectaindex/select_active_test.go
@@ -1,0 +1,48 @@
+package trifectaindex
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSelectActiveWorkOrder_DeterministicPriorityAndRecency(t *testing.T) {
+	now := time.Now().UTC()
+	older := now.Add(-time.Hour)
+
+	workOrders := []WorkOrder{
+		{ID: "WO-2", Status: WOStatusRunning, Priority: "P2", CreatedAt: now},
+		{ID: "WO-1", Status: WOStatusRunning, Priority: "P1", CreatedAt: older},
+		{ID: "WO-3", Status: WOStatusRunning, Priority: "P1", CreatedAt: now},
+		{ID: "WO-9", Status: WOStatusPending, Priority: "P0", CreatedAt: now},
+	}
+
+	sel := SelectActiveWorkOrder(workOrders)
+	if sel.ActiveWO == nil {
+		t.Fatalf("expected active WO, got nil")
+	}
+	if sel.ActiveWO.ID != "WO-3" {
+		t.Fatalf("expected WO-3, got %s", sel.ActiveWO.ID)
+	}
+	if sel.RunningCount != 3 {
+		t.Fatalf("expected running count 3, got %d", sel.RunningCount)
+	}
+	if sel.ExtraRunningCount != 2 {
+		t.Fatalf("expected extra count 2, got %d", sel.ExtraRunningCount)
+	}
+}
+
+func TestSelectActiveWorkOrder_TieBreakByID(t *testing.T) {
+	now := time.Now().UTC()
+	workOrders := []WorkOrder{
+		{ID: "WO-B", Status: WOStatusRunning, Priority: "P1", CreatedAt: now},
+		{ID: "WO-A", Status: WOStatusRunning, Priority: "P1", CreatedAt: now},
+	}
+
+	sel := SelectActiveWorkOrder(workOrders)
+	if sel.ActiveWO == nil {
+		t.Fatalf("expected active WO, got nil")
+	}
+	if sel.ActiveWO.ID != "WO-A" {
+		t.Fatalf("expected WO-A by ID tiebreak, got %s", sel.ActiveWO.ID)
+	}
+}

--- a/internal/trifectaindex/types.go
+++ b/internal/trifectaindex/types.go
@@ -1,0 +1,177 @@
+package trifectaindex
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// WOStatus represents the status of a Work Order
+type WOStatus string
+
+const (
+	// WOStatusPending indicates the WO is not yet started
+	WOStatusPending WOStatus = "pending"
+	// WOStatusRunning indicates the WO is currently being worked on
+	WOStatusRunning WOStatus = "running"
+	// WOStatusDone indicates the WO is completed
+	WOStatusDone WOStatus = "done"
+	// WOStatusFailed indicates the WO failed
+	WOStatusFailed WOStatus = "failed"
+)
+
+// WOIndex represents the complete Trifecta work order index
+type WOIndex struct {
+	Version            int         `json:"version"`
+	Schema             string      `json:"schema"`
+	GeneratedAt        time.Time   `json:"generated_at"`
+	RepoRoot           string      `json:"repo_root"`
+	GitHeadSHARepoRoot string      `json:"git_head_sha_repo_root"`
+	WorkOrders         []WorkOrder `json:"work_orders"`
+	Errors             []string    `json:"errors"`
+}
+
+// WorkOrder represents a single Trifecta Work Order
+type WorkOrder struct {
+	ID              string    `json:"id"`
+	Title           string    `json:"title"`
+	Status          WOStatus  `json:"status"`
+	Priority        string    `json:"priority"`
+	Owner           string    `json:"owner"`
+	EpicID          string    `json:"epic_id"`
+	WorktreePath    string    `json:"worktree_path"`
+	WorktreeExists  bool      `json:"worktree_exists"`
+	Branch          string    `json:"branch"`
+	WorktreeHeadSHA string    `json:"worktree_head_sha,omitempty"`
+	WOYAMLPath      string    `json:"wo_yaml_path"`
+	CreatedAt       time.Time `json:"created_at"`
+	ClosedAt        time.Time `json:"closed_at,omitempty"`
+	LastError       string    `json:"last_error,omitempty"`
+}
+
+const (
+	// ExpectedVersion is the supported version of the index format
+	ExpectedVersion = 1
+	// ExpectedSchema is the supported schema identifier
+	ExpectedSchema = "trifecta.sidecar.wo_index.v1"
+	// IndexFilename is the name of the index file
+	IndexFilename = "wo_worktrees.json"
+)
+
+// Validate checks that the index conforms to the expected schema
+func (idx *WOIndex) Validate() error {
+	if idx.Version != ExpectedVersion {
+		return fmt.Errorf("unsupported version: %d", idx.Version)
+	}
+	if idx.Schema != ExpectedSchema {
+		return fmt.Errorf("unsupported schema: %s", idx.Schema)
+	}
+	return nil
+}
+
+func parseTimestamp(raw string) (time.Time, error) {
+	layouts := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02 15:04:05Z07:00",
+		"2006-01-02 15:04:05",
+	}
+	var lastErr error
+	for _, layout := range layouts {
+		t, err := time.Parse(layout, raw)
+		if err == nil {
+			return t, nil
+		}
+		lastErr = err
+	}
+	return time.Time{}, lastErr
+}
+
+// UnmarshalJSON allows legacy space-separated generated_at values.
+func (idx *WOIndex) UnmarshalJSON(data []byte) error {
+	type alias struct {
+		Version            int         `json:"version"`
+		Schema             string      `json:"schema"`
+		GeneratedAt        string      `json:"generated_at"`
+		RepoRoot           string      `json:"repo_root"`
+		GitHeadSHARepoRoot string      `json:"git_head_sha_repo_root"`
+		WorkOrders         []WorkOrder `json:"work_orders"`
+		Errors             []string    `json:"errors"`
+	}
+
+	var aux alias
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	idx.Version = aux.Version
+	idx.Schema = aux.Schema
+	idx.RepoRoot = aux.RepoRoot
+	idx.GitHeadSHARepoRoot = aux.GitHeadSHARepoRoot
+	idx.WorkOrders = aux.WorkOrders
+	idx.Errors = aux.Errors
+	if aux.GeneratedAt != "" {
+		t, err := parseTimestamp(aux.GeneratedAt)
+		if err != nil {
+			return err
+		}
+		idx.GeneratedAt = t
+	}
+	return nil
+}
+
+// UnmarshalJSON allows empty created_at/closed_at values without failing load.
+func (wo *WorkOrder) UnmarshalJSON(data []byte) error {
+	type alias struct {
+		ID              string   `json:"id"`
+		Title           string   `json:"title"`
+		Status          WOStatus `json:"status"`
+		Priority        string   `json:"priority"`
+		Owner           string   `json:"owner"`
+		EpicID          string   `json:"epic_id"`
+		WorktreePath    string   `json:"worktree_path"`
+		WorktreeExists  bool     `json:"worktree_exists"`
+		Branch          string   `json:"branch"`
+		WorktreeHeadSHA string   `json:"worktree_head_sha,omitempty"`
+		WOYAMLPath      string   `json:"wo_yaml_path"`
+		CreatedAt       string   `json:"created_at"`
+		ClosedAt        *string  `json:"closed_at,omitempty"`
+		LastError       string   `json:"last_error,omitempty"`
+	}
+
+	var aux alias
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	wo.ID = aux.ID
+	wo.Title = aux.Title
+	wo.Status = aux.Status
+	wo.Priority = aux.Priority
+	wo.Owner = aux.Owner
+	wo.EpicID = aux.EpicID
+	wo.WorktreePath = aux.WorktreePath
+	wo.WorktreeExists = aux.WorktreeExists
+	wo.Branch = aux.Branch
+	wo.WorktreeHeadSHA = aux.WorktreeHeadSHA
+	wo.WOYAMLPath = aux.WOYAMLPath
+	wo.LastError = aux.LastError
+
+	if aux.CreatedAt != "" {
+		t, err := parseTimestamp(aux.CreatedAt)
+		if err != nil {
+			return err
+		}
+		wo.CreatedAt = t
+	}
+
+	if aux.ClosedAt != nil && *aux.ClosedAt != "" {
+		t, err := parseTimestamp(*aux.ClosedAt)
+		if err != nil {
+			return err
+		}
+		wo.ClosedAt = t
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- add shared trifecta WO index middleware (loader, schema validation, deterministic active selection)
- integrate middleware into tdmonitor and trifecta plugins
- surface active WO in TD CURRENT WORK and overlay with stable degraded states
- keep read-only behavior (no WO mutation actions)

## Scope
- internal/trifectaindex/*
- internal/plugins/tdmonitor/plugin.go
- internal/plugins/tdmonitor/trifecta_overlay_test.go
- internal/plugins/trifecta/*
- cmd/sidecar/main.go
- go.mod / go.sum

## Validation
- go test ./internal/trifectaindex ./internal/plugins/tdmonitor ./internal/plugins/trifecta
- make build

## Contract
- error codes: INDEX_MISSING, INDEX_INVALID_JSON, INDEX_SCHEMA_UNSUPPORTED, INDEX_REPO_MISMATCH
- deterministic selector: running only, priority desc, recency desc, id asc fallback
