### PR TITLE
fix: use standard diagnostic status strings for fsnotify watcher

### DIFF
--- a/internal/plugins/conversations/plugin.go
+++ b/internal/plugins/conversations/plugin.go
@@ -1233,9 +1233,9 @@ func (p *Plugin) Diagnostics() []plugin.Diagnostic {
 	}
 
 	// Add watcher status
-	watchStatus := "off"
+	watchStatus := "error"
 	if p.watchChan != nil {
-		watchStatus = "on"
+		watchStatus = "ok"
 	}
 
 	return []plugin.Diagnostic{

--- a/internal/plugins/conversations/plugin_test.go
+++ b/internal/plugins/conversations/plugin_test.go
@@ -398,8 +398,8 @@ func TestDiagnosticsWatcherOn(t *testing.T) {
 		t.Fatalf("expected 2 diagnostics, got %d", len(diags))
 	}
 
-	if diags[1].Status != "on" {
-		t.Errorf("expected watcher status 'on', got %q", diags[1].Status)
+	if diags[1].Status != "ok" {
+		t.Errorf("expected watcher status 'ok', got %q", diags[1].Status)
 	}
 }
 


### PR DESCRIPTION
The conversations plugin Diagnostics() returned 'on'/'off' for watcher status, but the diagnostics modal only recognizes 'ok', 'warning', and 'error' for colored status icons. 'on' fell to the default case, rendering the fsnotify entry as muted/dim instead of lit.

Changed watcher status from 'on'/'off' to 'ok'/'error'.