### PR TITLE
docs: add doc.go to notes, pricing, and tdroot packages

### DIFF
--- a/internal/adapter/pricing/doc.go
+++ b/internal/adapter/pricing/doc.go
@@ -1,0 +1,3 @@
+// Package pricing calculates Claude API costs from token usage with
+// cache-aware input pricing and version-specific model tiers.
+package pricing

--- a/internal/plugins/notes/doc.go
+++ b/internal/plugins/notes/doc.go
@@ -1,0 +1,3 @@
+// Package notes implements a dual-pane note-taking plugin with SQLite persistence,
+// full-text search, inline editing, and td task integration.
+package notes

--- a/internal/tdroot/doc.go
+++ b/internal/tdroot/doc.go
@@ -1,0 +1,3 @@
+// Package tdroot resolves td's root directory and database paths, handling
+// the .td-root file mechanism for sharing a td database across git worktrees.
+package tdroot

--- a/internal/tdroot/tdroot.go
+++ b/internal/tdroot/tdroot.go
@@ -1,5 +1,3 @@
-// Package tdroot provides utilities for resolving td's root directory and database paths.
-// It handles the .td-root file mechanism used to share a td database across git worktrees.
 package tdroot
 
 import (


### PR DESCRIPTION
## Summary
- Add `doc.go` to `internal/plugins/notes`, `internal/adapter/pricing`, and `internal/tdroot` — the three packages missing package-level documentation
- Move the existing inline doc comment from `tdroot.go` into the new `doc.go` to match project convention
- All other 38 packages already had `doc.go` files; this brings coverage to 100%

## Test plan
- [x] `go build ./...` passes
- [x] `go vet` passes on all three packages
- [x] `go test` passes on all three packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: docs-backfill:/Users/marcusvorwaller/code/sidecar
task-type: docs-backfill
task-title: Documentation Backfiller
provider: claude
score: 3.7
cost-tier: Low (10-50k)
iterations: 1
duration: 5m54s
run-started: 2026-02-13T02:00:00-08:00
nightshift:metadata -->
