### PR TITLE
fix: filter mouse escape fragments leaking into dialogs on Linux

### DIFF
--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -250,6 +250,9 @@ type Model struct {
 
 	// Intro animation
 	intro IntroModel
+
+	// Mouse fragment suppression (Linux SGR sequence splitting)
+	recentMouseEvent bool
 }
 
 // New creates a new application model.

--- a/internal/app/project_add_modal.go
+++ b/internal/app/project_add_modal.go
@@ -116,11 +116,6 @@ func (m *Model) projectAddNameUpdate(msg tea.Msg, focusID string) (string, tea.C
 		return "", nil
 	}
 
-	// Filter out unparsed mouse escape sequences
-	if isMouseEscapeSequence(keyMsg) {
-		return "", nil
-	}
-
 	// Clear error on typing
 	m.projectAdd.errorMessage = ""
 	m.projectAddModalWidth = 0 // Force rebuild to hide error
@@ -184,11 +179,6 @@ func (m *Model) projectAddPathUpdate(msg tea.Msg, focusID string) (string, tea.C
 
 	keyMsg, ok := msg.(tea.KeyMsg)
 	if !ok {
-		return "", nil
-	}
-
-	// Filter out unparsed mouse escape sequences
-	if isMouseEscapeSequence(keyMsg) {
 		return "", nil
 	}
 


### PR DESCRIPTION
## Summary

<img width="488" height="213" alt="Screenshot From 2026-02-13 18-55-38" src="https://github.com/user-attachments/assets/3a37deca-90cc-4ccd-b708-9d483f8df2c8" />


Fix mouse escape sequence fragments leaking into dialogs as garbage text on Linux (Gnome with Ptyxis emulator). On Linux, terminal emulators split SGR mouse sequences across `read()` boundaries, causing Bubble Tea to deliver fragments like `[<67;78;9M` as `KeyMsg` instead of `MouseMsg`. These fragments appear as typed garbage in modal text inputs and can trigger unintended keybindings (e.g., `[` → `prev-tab`).

**Root cause**: The existing `isMouseEscapeSequence()` filter was too strict (required trailing `M`/`m`, missing truncated fragments) and was only applied in 5 of 11 modal handlers.

**Fix**: Add a single, early universal filter in `handleKeyMsg()` that catches all fragment types before any modal/plugin routing. This uses the existing, well-tested `tty.LooksLikeMouseFragment()` plus a `recentMouseEvent` flag for bare `[` suppression. Then remove all redundant per-modal filters.

## Changes Made

- **`internal/app/model.go`**: Add `recentMouseEvent bool` field for tracking proximity to mouse events
- **`internal/app/update.go`**:
  - Set `recentMouseEvent = true` on every `tea.MouseMsg`
  - Add universal mouse fragment filter early in `handleKeyMsg()` (after Esc handling, before any modal/plugin routing)
  - Uses zero-allocation fast path: checks runes directly, only calls `LooksLikeMouseFragment` when first rune suggests mouse data
  - Remove `isMouseEscapeSequence()` function definition and all 5 call sites
  - Add `tty` package import
- **`internal/app/project_add_modal.go`**: Remove 2 `isMouseEscapeSequence()` call sites

Net result: **-27 lines** (24 added, 51 removed)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test

1. Build and run sidecar on a **Linux** system (GNOME Terminal, kitty, or similar)
2. Open the project switcher (`@`) and move the mouse / scroll — no garbage should appear in the filter input
3. Open Create New Worktree (`n`) and move the mouse — no fragments in the name field
4. Open theme switcher (`#`), help (`?`), quit confirm (`ctrl+c`), diagnostics — mouse interaction should not cause unexpected behavior
5. Verify `[` key still works for `prev-tab` / `prev-file` navigation when no mouse is active
6. On macOS: verify no false positives (all modals work normally)

## Verification
- [x] `go build ./...` passes
- [x] `go test ./internal/app/...` passes
- [x] `go test ./internal/tty/...` passes
- [x] `go vet ./...` passes
- [x] Manual testing on Linux (GNOME Terminal) — confirmed fragments no longer leak into Create New Worktree dialog

## Additional Notes

- This is a **Linux-only** issue. macOS terminals deliver escape sequences atomically in a single `read()`, so Bubble Tea always successfully parses them.
- The existing `tty.LooksLikeMouseFragment()` function (in `internal/tty/output_buffer.go`) already had comprehensive tests — no changes needed to that function.
- **Pre-existing mouse motion event flooding (causing click delay during rapid mouse movement) is a separate issue affecting Linux** (I do not observe it on macOS), unrelated to this fix. Moving the mouse effectively freezes the UI dialog elements.
