### PR TITLE
docs: add privacy policy

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,45 @@
+# Privacy
+
+Sidecar is a local-first terminal application. This document describes exactly what data it accesses and what network requests it makes.
+
+## Local Data Access
+
+Sidecar reads local files to populate its plugins. It never modifies files outside its own config and state directories.
+
+**Git data** — Runs `git` commands (status, diff, log, worktree) in the current project directory.
+
+**AI agent sessions** — Reads conversation history from local agent data directories to display in the Conversations plugin:
+- Claude Code: `~/.claude/projects/` and `~/.config/claude/projects/`
+- Cursor: `~/.cursor/chats/`
+- Codex: `~/.codex/sessions/`
+- Warp: `~/Library/Application Support/dev.warp.Warp-Stable/`
+- Gemini CLI, Amp, Kiro, OpenCode: their respective local session directories
+
+These files are read-only. Sidecar never writes to agent data directories.
+
+**Config and state** — Reads and writes its own configuration (`~/.config/sidecar/config.json`) and persistent state (`~/.config/sidecar/state.json`). Debug logs go to `~/.config/sidecar/debug.log`.
+
+**TD tasks** — If [td](https://github.com/marcus/td) is installed, sidecar runs `td` CLI commands to display tasks.
+
+## Network Requests
+
+Sidecar makes **two** outbound HTTP requests, both to the GitHub API:
+
+1. **Version check** — On startup, fetches the latest release tag from `api.github.com/repos/marcus/sidecar/releases/latest` and `api.github.com/repos/marcus/td/releases/latest` to show an update notification. These requests have a 5-second timeout and no authentication.
+
+2. **Changelog fetch** — When you open the changelog from the update modal, fetches `raw.githubusercontent.com/marcus/sidecar/main/CHANGELOG.md` (10-second timeout).
+
+The Workspaces plugin runs `gh` CLI commands locally (e.g., `gh pr list`, `gh pr create`). These use your existing GitHub CLI authentication and only run in response to explicit user actions.
+
+## What Sidecar Does NOT Do
+
+- No telemetry, analytics, or usage tracking
+- No crash reporting
+- No data transmitted to any server other than the GitHub API calls listed above
+- No account or login required
+- No cookies, local storage, or browser fingerprinting
+- Pprof profiling server only starts when you explicitly set `SIDECAR_PPROF`
+
+## Opting Out of Network Requests
+
+Version checks are skipped automatically for development builds (untagged or `devel` versions). There is currently no config flag to disable version checks on release builds. If you need fully offline operation, run sidecar with network access blocked at the OS or firewall level.

--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ make lint-all     # Lint entire codebase (includes legacy debt)
 - Enforcement: CI runs tests and blocks new lint issues on PRs (`.github/workflows/go-ci.yml`)
 - Debt tracking: run `make lint-all` to measure and burn down legacy lint debt
 
+## Privacy
+
+Sidecar runs locally and makes no telemetry or analytics calls. It makes two outbound requests to the GitHub API on startup to check for updates. See [PRIVACY.md](PRIVACY.md) for full details.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Adds `PRIVACY.md` documenting sidecar's actual data practices: local file reads (git, agent sessions, config), outbound network requests (GitHub API version checks, changelog fetch), and explicit "what we don't do" section (no telemetry, analytics, crash reporting)
- Adds a Privacy section to `README.md` linking to the new file

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Review PRIVACY.md claims against codebase (all network calls verified via grep for `net/http` and `http.Client`)

Nightshift-Task: privacy-policy
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)