### PR TITLE
fix: use --no-optional-locks for background git operations

### DIFF
--- a/internal/app/git.go
+++ b/internal/app/git.go
@@ -33,14 +33,14 @@ type WorktreeInfo struct {
 // Returns nil if workDir is not in a git repository.
 func GetWorktrees(workDir string) []WorktreeInfo {
 	// First, verify this is a git repo
-	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd := exec.Command("git", "--no-optional-locks", "rev-parse", "--git-dir")
 	cmd.Dir = workDir
 	if err := cmd.Run(); err != nil {
 		return nil
 	}
 
 	// Get list of worktrees
-	cmd = exec.Command("git", "worktree", "list", "--porcelain")
+	cmd = exec.Command("git", "--no-optional-locks", "worktree", "list", "--porcelain")
 	cmd.Dir = workDir
 	output, err := cmd.Output()
 	if err != nil {
@@ -150,14 +150,14 @@ func WorktreeNameForPath(workDir, targetPath string) string {
 // Returns empty string if the directory is not a git repository.
 func GetRepoName(workDir string) string {
 	// Check if this is a git repo
-	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd := exec.Command("git", "--no-optional-locks", "rev-parse", "--git-dir")
 	cmd.Dir = workDir
 	if err := cmd.Run(); err != nil {
 		return ""
 	}
 
 	// Try to get remote URL
-	cmd = exec.Command("git", "remote", "get-url", "origin")
+	cmd = exec.Command("git", "--no-optional-locks", "remote", "get-url", "origin")
 	cmd.Dir = workDir
 	output, err := cmd.Output()
 	if err == nil {

--- a/internal/plugins/gitstatus/branch.go
+++ b/internal/plugins/gitstatus/branch.go
@@ -24,7 +24,7 @@ type Branch struct {
 func GetBranches(workDir string) ([]*Branch, error) {
 	// Use git branch with format to get detailed info
 	// Format: refname:short, HEAD, upstream:short, upstream:track
-	cmd := exec.Command("git", "branch",
+	cmd := gitReadOnly("branch",
 		"--format=%(refname:short)|%(HEAD)|%(upstream:short)|%(upstream:track)")
 	cmd.Dir = workDir
 	output, err := cmd.Output()

--- a/internal/plugins/gitstatus/diff.go
+++ b/internal/plugins/gitstatus/diff.go
@@ -16,7 +16,7 @@ func GetDiff(workDir, path string, staged bool) (string, error) {
 	}
 	args = append(args, "--", path)
 
-	cmd := exec.Command("git", args...)
+	cmd := gitReadOnly(args...)
 	cmd.Dir = workDir
 	output, err := cmd.Output()
 	if err != nil {
@@ -39,7 +39,7 @@ func GetFullDiff(workDir string, staged bool) (string, error) {
 		args = append(args, "--cached")
 	}
 
-	cmd := exec.Command("git", args...)
+	cmd := gitReadOnly(args...)
 	cmd.Dir = workDir
 	output, err := cmd.Output()
 	if err != nil {
@@ -62,7 +62,7 @@ func GetFileDiffStats(workDir, path string, staged bool) (int, int, error) {
 	}
 	args = append(args, "--", path)
 
-	cmd := exec.Command("git", args...)
+	cmd := gitReadOnly(args...)
 	cmd.Dir = workDir
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/plugins/gitstatus/gitcmd.go
+++ b/internal/plugins/gitstatus/gitcmd.go
@@ -1,0 +1,14 @@
+package gitstatus
+
+import "os/exec"
+
+// gitReadOnly creates an exec.Cmd for a read-only git operation that won't
+// acquire optional locks. This prevents .git/index.lock conflicts when the
+// file watcher triggers a background refresh while a write operation (stage,
+// commit, checkout, etc.) is in progress.
+//
+// Uses the --no-optional-locks flag (git 2.15+), which is the standard
+// approach for background monitoring tools (VS Code, JetBrains, etc.).
+func gitReadOnly(args ...string) *exec.Cmd {
+	return exec.Command("git", append([]string{"--no-optional-locks"}, args...)...)
+}

--- a/internal/plugins/gitstatus/github.go
+++ b/internal/plugins/gitstatus/github.go
@@ -20,7 +20,7 @@ type GitHubInfo struct {
 
 // GetRemoteURL returns the URL for the primary remote (origin).
 func GetRemoteURL(workDir string) string {
-	cmd := exec.Command("git", "remote", "get-url", "origin")
+	cmd := gitReadOnly("remote", "get-url", "origin")
 	cmd.Dir = workDir
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/plugins/gitstatus/history.go
+++ b/internal/plugins/gitstatus/history.go
@@ -45,7 +45,7 @@ func GetCommitHistory(workDir string, limit int) ([]*Commit, error) {
 	format := "%H%x00%h%x00%an%x00%ae%x00%at%x00%s%x00%P"
 	args := []string{"log", "--format=" + format, "-n", strconv.Itoa(limit)}
 
-	cmd := exec.Command("git", args...)
+	cmd := gitReadOnly(args...)
 	cmd.Dir = workDir
 	output, err := cmd.Output()
 	if err != nil {
@@ -90,7 +90,7 @@ func GetCommitHistory(workDir string, limit int) ([]*Commit, error) {
 func GetCommitDetail(workDir, hash string) (*Commit, error) {
 	// Get commit metadata (%P = parent hashes for merge detection)
 	format := "%H%n%h%n%an%n%ae%n%at%n%P%n%s%n%b"
-	cmd := exec.Command("git", "show", "--format="+format, "-s", hash)
+	cmd := gitReadOnly("show", "--format="+format, "-s", hash)
 	cmd.Dir = workDir
 	output, err := cmd.Output()
 	if err != nil {
@@ -126,9 +126,9 @@ func GetCommitDetail(workDir, hash string) (*Commit, error) {
 
 	// Get file stats — for merge commits, diff against first parent to avoid empty combined diff
 	if commit.IsMerge && len(commit.ParentHashes) > 0 {
-		cmd = exec.Command("git", "diff", "--numstat", commit.ParentHashes[0], hash)
+		cmd = gitReadOnly("diff", "--numstat", commit.ParentHashes[0], hash)
 	} else {
-		cmd = exec.Command("git", "show", "--numstat", "--format=", hash)
+		cmd = gitReadOnly("show", "--numstat", "--format=", hash)
 	}
 	cmd.Dir = workDir
 	output, err = cmd.Output()
@@ -202,7 +202,7 @@ func GetCommitDiff(workDir, hash, path string, parentHash string) (string, error
 		args = []string{"show", hash, "--", path}
 	}
 
-	cmd := exec.Command("git", args...)
+	cmd := gitReadOnly(args...)
 	cmd.Dir = workDir
 	output, err := cmd.Output()
 	if err != nil {
@@ -219,7 +219,7 @@ func GetCommitDiff(workDir, hash, path string, parentHash string) (string, error
 
 // GetCommitFullDiff returns the full diff for a commit.
 func GetCommitFullDiff(workDir, hash string) (string, error) {
-	cmd := exec.Command("git", "show", hash)
+	cmd := gitReadOnly("show", hash)
 	cmd.Dir = workDir
 	output, err := cmd.Output()
 	if err != nil {
@@ -258,7 +258,7 @@ func GetCommitHistoryWithOffset(workDir string, limit, skip int) ([]*Commit, err
 	format := "%H%x00%h%x00%an%x00%ae%x00%at%x00%s%x00%P"
 	args := []string{"log", "--format=" + format, "-n", strconv.Itoa(limit), "--skip", strconv.Itoa(skip)}
 
-	cmd := exec.Command("git", args...)
+	cmd := gitReadOnly(args...)
 	cmd.Dir = workDir
 	output, err := cmd.Output()
 	if err != nil {
@@ -340,7 +340,7 @@ func GetCommitHistoryFiltered(workDir string, opts HistoryFilterOpts) ([]*Commit
 		args = append(args, "--", opts.Path)
 	}
 
-	cmd := exec.Command("git", args...)
+	cmd := gitReadOnly(args...)
 	cmd.Dir = workDir
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/plugins/gitstatus/plugin.go
+++ b/internal/plugins/gitstatus/plugin.go
@@ -3,7 +3,6 @@ package gitstatus
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -244,7 +243,7 @@ func (p *Plugin) Icon() string { return pluginIcon }
 // resolveGitRoot returns the top-level directory of the git repository
 // containing dir, or an error if dir is not inside a git repo.
 func resolveGitRoot(dir string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd := gitReadOnly("rev-parse", "--show-toplevel")
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/plugins/gitstatus/push.go
+++ b/internal/plugins/gitstatus/push.go
@@ -27,7 +27,7 @@ func GetPushStatus(workDir string) *PushStatus {
 	status := &PushStatus{}
 
 	// Check if HEAD is detached
-	branchCmd := exec.Command("git", "branch", "--show-current")
+	branchCmd := gitReadOnly("branch", "--show-current")
 	branchCmd.Dir = workDir
 	branchOutput, err := branchCmd.Output()
 	if err != nil {
@@ -41,7 +41,7 @@ func GetPushStatus(workDir string) *PushStatus {
 	}
 
 	// Get upstream branch name
-	upstreamCmd := exec.Command("git", "rev-parse", "--abbrev-ref", "@{upstream}")
+	upstreamCmd := gitReadOnly("rev-parse", "--abbrev-ref", "@{upstream}")
 	upstreamCmd.Dir = workDir
 	upstreamOutput, err := upstreamCmd.Output()
 	if err != nil {
@@ -55,7 +55,7 @@ func GetPushStatus(workDir string) *PushStatus {
 
 	// Get ahead/behind counts
 	// Format: "X\tY" where X is behind, Y is ahead
-	countCmd := exec.Command("git", "rev-list", "--count", "--left-right", "@{upstream}...HEAD")
+	countCmd := gitReadOnly("rev-list", "--count", "--left-right", "@{upstream}...HEAD")
 	countCmd.Dir = workDir
 	countOutput, err := countCmd.Output()
 	if err == nil {
@@ -69,7 +69,7 @@ func GetPushStatus(workDir string) *PushStatus {
 	// Get unpushed commit hashes if we're ahead
 	if status.Ahead > 0 {
 		// Use upstream..HEAD to get commits that are in HEAD but not in upstream
-		logCmd := exec.Command("git", "log", "@{upstream}..HEAD", "--format=%H")
+		logCmd := gitReadOnly("log", "@{upstream}..HEAD", "--format=%H")
 		logCmd.Dir = workDir
 		logOutput, err := logCmd.Output()
 		if err == nil {
@@ -151,7 +151,7 @@ func isPushRejectedError(err error) bool {
 // GetRemoteName returns the primary remote name (usually "origin").
 // Returns empty string if no remotes are configured.
 func GetRemoteName(workDir string) string {
-	cmd := exec.Command("git", "remote")
+	cmd := gitReadOnly("remote")
 	cmd.Dir = workDir
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/plugins/gitstatus/remote.go
+++ b/internal/plugins/gitstatus/remote.go
@@ -63,7 +63,7 @@ func ExecutePullAutostash(workDir string) (string, error) {
 
 // GetConflictedFiles returns a list of files with merge conflicts.
 func GetConflictedFiles(workDir string) []string {
-	cmd := exec.Command("git", "diff", "--name-only", "--diff-filter=U")
+	cmd := gitReadOnly("diff", "--name-only", "--diff-filter=U")
 	cmd.Dir = workDir
 	output, err := cmd.Output()
 	if err != nil {
@@ -109,7 +109,7 @@ func AbortRebase(workDir string) error {
 
 // IsRebaseInProgress checks if a rebase is currently in progress.
 func IsRebaseInProgress(workDir string) bool {
-	cmd := exec.Command("git", "rev-parse", "--git-path", "rebase-merge")
+	cmd := gitReadOnly("rev-parse", "--git-path", "rebase-merge")
 	cmd.Dir = workDir
 	output, err := cmd.Output()
 	if err != nil {
@@ -119,7 +119,7 @@ func IsRebaseInProgress(workDir string) bool {
 	if _, err := os.Stat(path); err == nil {
 		return true
 	}
-	cmd = exec.Command("git", "rev-parse", "--git-path", "rebase-apply")
+	cmd = gitReadOnly("rev-parse", "--git-path", "rebase-apply")
 	cmd.Dir = workDir
 	output, err = cmd.Output()
 	if err != nil {

--- a/internal/plugins/gitstatus/stash.go
+++ b/internal/plugins/gitstatus/stash.go
@@ -23,7 +23,7 @@ type StashList struct {
 
 // GetStashList retrieves the list of stashes.
 func GetStashList(workDir string) (*StashList, error) {
-	cmd := exec.Command("git", "stash", "list", "--format=%gd|%gs")
+	cmd := gitReadOnly("stash", "list", "--format=%gd|%gs")
 	cmd.Dir = workDir
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/plugins/gitstatus/tree.go
+++ b/internal/plugins/gitstatus/tree.go
@@ -63,7 +63,7 @@ func NewFileTree(workDir string) *FileTree {
 func (t *FileTree) Refresh() error {
 	// Run git status with porcelain v2 format (null-separated)
 	// Use --untracked-files=all to recursively list all files in untracked folders
-	cmd := exec.Command("git", "status", "--porcelain=v2", "-z", "--untracked-files=all")
+	cmd := gitReadOnly("status", "--porcelain=v2", "-z", "--untracked-files=all")
 	cmd.Dir = t.workDir
 	output, err := cmd.Output()
 	if err != nil {
@@ -265,7 +265,7 @@ func (t *FileTree) loadDiffStatsFor(staged bool) error {
 		args = append(args, "--cached")
 	}
 
-	cmd := exec.Command("git", args...)
+	cmd := gitReadOnly(args...)
 	cmd.Dir = t.workDir
 	output, err := cmd.Output()
 	if err != nil {
@@ -509,7 +509,7 @@ func ExecuteAmend(workDir, message string) (string, error) {
 
 // getLastCommitMessage returns the message of the most recent commit.
 func getLastCommitMessage(workDir string) string {
-	cmd := exec.Command("git", "log", "-1", "--format=%B")
+	cmd := gitReadOnly("log", "-1", "--format=%B")
 	cmd.Dir = workDir
 	output, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
Prevents index.lock conflicts when the file watcher triggers git status refreshes while write operations (stage, commit, checkout) are in progress. 
All read-only git commands now use --no-optional-locks (git 2.15+), the standard approach for background monitoring tools.
Fixes #185