### PR TITLE
feat: add run plugin for executing project commands

### DIFF
--- a/cmd/sidecar/main.go
+++ b/cmd/sidecar/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/marcus/sidecar/internal/plugins/filebrowser"
 	"github.com/marcus/sidecar/internal/plugins/gitstatus"
 	"github.com/marcus/sidecar/internal/plugins/notes"
+	"github.com/marcus/sidecar/internal/plugins/run"
 	"github.com/marcus/sidecar/internal/plugins/tdmonitor"
 	"github.com/marcus/sidecar/internal/plugins/workspace"
 	"github.com/marcus/sidecar/internal/state"
@@ -188,6 +189,11 @@ func main() {
 	if features.IsEnabled("notes_plugin") {
 		if err := registry.Register(notes.New()); err != nil {
 			logger.Warn("failed to register notes plugin", "err", err)
+		}
+	}
+	if features.IsEnabled("run_plugin") {
+		if err := registry.Register(run.New()); err != nil {
+			logger.Warn("failed to register run plugin", "err", err)
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,7 @@ type PluginsConfig struct {
 	Conversations ConversationsPluginConfig `json:"conversations"`
 	Workspace     WorkspacePluginConfig     `json:"workspace"`
 	Notes         NotesPluginConfig         `json:"notes"`
+	Run           RunPluginConfig           `json:"run"`
 }
 
 // GitStatusPluginConfig configures the git status plugin.
@@ -87,6 +88,18 @@ type NotesPluginConfig struct {
 	// Values: "builtin" (default), "vim", "nvim", or any $EDITOR value.
 	// When set to "vim"/"nvim", Enter opens the note in inline vim instead of built-in editor.
 	DefaultEditor string `json:"defaultEditor,omitempty"`
+}
+
+// RunPluginConfig configures the run plugin.
+type RunPluginConfig struct {
+	Commands []RunCommandConfig `json:"commands,omitempty"` // Manual commands
+}
+
+// RunCommandConfig represents a manually configured run command.
+type RunCommandConfig struct {
+	Name    string `json:"name"`            // Display name
+	Command string `json:"command"`         // Shell command to execute
+	Group   string `json:"group,omitempty"` // Optional grouping (e.g., "docker", "npm")
 }
 
 // KeymapConfig holds key binding overrides.

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -39,6 +39,13 @@ var (
 		Default:     false,
 		Description: "Enable the notes plugin for capturing quick notes",
 	}
+
+	// RunPlugin enables the run plugin for executing project commands.
+	RunPlugin = Feature{
+		Name:        "run_plugin",
+		Default:     false,
+		Description: "Enable the run plugin for executing project commands",
+	}
 )
 
 // allFeatures is the registry of all known features.
@@ -46,6 +53,7 @@ var allFeatures = []Feature{
 	TmuxInteractiveInput,
 	TmuxInlineEdit,
 	NotesPlugin,
+	RunPlugin,
 }
 
 // defaultValues provides O(1) lookup for feature defaults.

--- a/internal/keymap/bindings.go
+++ b/internal/keymap/bindings.go
@@ -460,6 +460,32 @@ func DefaultBindings() []Binding {
 		{Key: "esc", Command: "cancel", Context: "notes-task-modal"},
 		{Key: "tab", Command: "next-field", Context: "notes-task-modal"},
 		{Key: "shift+tab", Command: "prev-field", Context: "notes-task-modal"},
+
+		// Run plugin list context
+		{Key: "j", Command: "cursor-down", Context: "run-list"},
+		{Key: "k", Command: "cursor-up", Context: "run-list"},
+		{Key: "down", Command: "cursor-down", Context: "run-list"},
+		{Key: "up", Command: "cursor-up", Context: "run-list"},
+		{Key: "enter", Command: "run", Context: "run-list"},
+		{Key: "x", Command: "stop", Context: "run-list"},
+		{Key: "r", Command: "refresh", Context: "run-list"},
+		{Key: "tab", Command: "switch-pane", Context: "run-list"},
+		{Key: "l", Command: "focus-right", Context: "run-list"},
+		{Key: "right", Command: "focus-right", Context: "run-list"},
+		{Key: "G", Command: "cursor-bottom", Context: "run-list"},
+
+		// Run plugin output context
+		{Key: "tab", Command: "switch-pane", Context: "run-output"},
+		{Key: "h", Command: "focus-left", Context: "run-output"},
+		{Key: "left", Command: "focus-left", Context: "run-output"},
+		{Key: "esc", Command: "focus-left", Context: "run-output"},
+		{Key: "j", Command: "scroll-down", Context: "run-output"},
+		{Key: "k", Command: "scroll-up", Context: "run-output"},
+		{Key: "down", Command: "scroll-down", Context: "run-output"},
+		{Key: "up", Command: "scroll-up", Context: "run-output"},
+		{Key: "ctrl+d", Command: "page-down", Context: "run-output"},
+		{Key: "ctrl+u", Command: "page-up", Context: "run-output"},
+		{Key: "x", Command: "stop", Context: "run-output"},
 	}
 }
 

--- a/internal/plugins/run/commands.go
+++ b/internal/plugins/run/commands.go
@@ -1,0 +1,42 @@
+package run
+
+import "github.com/marcus/sidecar/internal/plugin"
+
+// Commands returns the available commands for the footer.
+func (p *Plugin) Commands() []plugin.Command {
+	if p.activePane == PaneOutput {
+		cmds := []plugin.Command{
+			{ID: "switch-pane", Name: "Focus", Description: "Switch to command list", Context: "run-output", Priority: 1},
+		}
+		session := p.selectedSession()
+		if session != nil && session.Status == StatusRunning {
+			cmds = append(cmds, plugin.Command{ID: "stop", Name: "Stop", Description: "Stop running command", Context: "run-output", Priority: 2})
+		}
+		return cmds
+	}
+
+	// List pane commands
+	cmds := []plugin.Command{
+		{ID: "run", Name: "Run", Description: "Run selected command", Context: "run-list", Priority: 1},
+		{ID: "refresh", Name: "Refresh", Description: "Re-detect commands", Context: "run-list", Priority: 2},
+	}
+
+	session := p.selectedSession()
+	if session != nil && session.Status == StatusRunning {
+		cmds = append(cmds, plugin.Command{ID: "stop", Name: "Stop", Description: "Stop running command", Context: "run-list", Priority: 3})
+	}
+
+	if session != nil {
+		cmds = append(cmds, plugin.Command{ID: "switch-pane", Name: "Output", Description: "View command output", Context: "run-list", Priority: 4})
+	}
+
+	return cmds
+}
+
+// FocusContext returns the current focus context for keybinding dispatch.
+func (p *Plugin) FocusContext() string {
+	if p.activePane == PaneOutput {
+		return "run-output"
+	}
+	return "run-list"
+}

--- a/internal/plugins/run/detector.go
+++ b/internal/plugins/run/detector.go
@@ -1,0 +1,276 @@
+package run
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// RunCommand represents a detected or configured runnable command.
+type RunCommand struct {
+	Name    string // Display name (e.g., "build", "test")
+	Command string // Shell command to execute
+	Source  string // Source label (e.g., "Makefile", "npm", "docker", "config")
+	Group   string // Grouping key for display
+}
+
+// detectCommands scans the working directory for runnable commands.
+func detectCommands(workDir string) []RunCommand {
+	var commands []RunCommand
+
+	commands = append(commands, detectMakefile(workDir)...)
+	commands = append(commands, detectPackageJSON(workDir)...)
+	commands = append(commands, detectDockerCompose(workDir)...)
+	commands = append(commands, detectPyproject(workDir)...)
+
+	return commands
+}
+
+// makefileTargetPattern matches non-hidden Makefile targets (lines like "target:" without leading tab/dot).
+var makefileTargetPattern = regexp.MustCompile(`^([a-zA-Z0-9][a-zA-Z0-9_.-]*)\s*:`)
+
+// detectMakefile parses a Makefile for targets.
+func detectMakefile(workDir string) []RunCommand {
+	path := filepath.Join(workDir, "Makefile")
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var commands []RunCommand
+	seen := make(map[string]bool)
+	scanner := bufio.NewScanner(f)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		matches := makefileTargetPattern.FindStringSubmatch(line)
+		if matches == nil {
+			continue
+		}
+		target := matches[1]
+		// Skip common internal/hidden targets
+		if strings.HasPrefix(target, ".") || target == "PHONY" {
+			continue
+		}
+		if seen[target] {
+			continue
+		}
+		seen[target] = true
+		commands = append(commands, RunCommand{
+			Name:    target,
+			Command: "make " + target,
+			Source:  "Makefile",
+			Group:   "make",
+		})
+	}
+	return commands
+}
+
+// detectPackageManager returns the package manager runner command and label
+// by checking for lockfiles in priority order.
+func detectPackageManager(workDir string) (runner string, label string) {
+	// Check lockfiles in order of specificity
+	lockfiles := []struct {
+		file   string
+		runner string
+		label  string
+	}{
+		{"bun.lockb", "bun run", "bun"},
+		{"bun.lock", "bun run", "bun"},
+		{"pnpm-lock.yaml", "pnpm run", "pnpm"},
+		{"yarn.lock", "yarn", "yarn"}, // yarn doesn't need "run" for scripts
+		{"package-lock.json", "npm run", "npm"},
+	}
+	for _, lf := range lockfiles {
+		if _, err := os.Stat(filepath.Join(workDir, lf.file)); err == nil {
+			return lf.runner, lf.label
+		}
+	}
+	// Default to npm if no lockfile found
+	return "npm run", "npm"
+}
+
+// detectPackageJSON parses package.json for scripts.
+func detectPackageJSON(workDir string) []RunCommand {
+	path := filepath.Join(workDir, "package.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	var pkg struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil
+	}
+
+	runner, label := detectPackageManager(workDir)
+
+	var commands []RunCommand
+	// Sort script names for stable ordering
+	names := make([]string, 0, len(pkg.Scripts))
+	for name := range pkg.Scripts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		commands = append(commands, RunCommand{
+			Name:    name,
+			Command: runner + " " + name,
+			Source:  label,
+			Group:   label,
+		})
+	}
+	return commands
+}
+
+// detectDockerCompose parses docker-compose.yml for services.
+func detectDockerCompose(workDir string) []RunCommand {
+	// Try both filenames
+	var data []byte
+	var err error
+	for _, name := range []string{"docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"} {
+		data, err = os.ReadFile(filepath.Join(workDir, name))
+		if err == nil {
+			break
+		}
+	}
+	if data == nil {
+		return nil
+	}
+
+	// Simple YAML parsing: look for top-level "services:" and then indented service names
+	var commands []RunCommand
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	inServices := false
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "services:" {
+			inServices = true
+			continue
+		}
+
+		if inServices {
+			// A service is a line with exactly 2 spaces of indent followed by "name:"
+			if len(line) > 2 && line[0] == ' ' && line[1] == ' ' && line[2] != ' ' && strings.HasSuffix(trimmed, ":") {
+				serviceName := strings.TrimSuffix(trimmed, ":")
+				commands = append(commands, RunCommand{
+					Name:    serviceName,
+					Command: "docker compose up " + serviceName,
+					Source:  "docker",
+					Group:   "docker",
+				})
+			} else if len(line) > 0 && line[0] != ' ' && line[0] != '#' {
+				// Hit another top-level key, stop parsing services
+				inServices = false
+			}
+		}
+	}
+	return commands
+}
+
+// detectPythonPackageManager returns the runner command and label
+// by checking for Python lockfiles/markers.
+func detectPythonPackageManager(workDir string) (runner string, label string) {
+	// Check lockfiles in order of specificity
+	lockfiles := []struct {
+		file   string
+		runner string
+		label  string
+	}{
+		{"uv.lock", "uv run", "uv"},
+		{"poetry.lock", "poetry run", "poetry"},
+	}
+	for _, lf := range lockfiles {
+		if _, err := os.Stat(filepath.Join(workDir, lf.file)); err == nil {
+			return lf.runner, lf.label
+		}
+	}
+	// Default to uv if no lockfile found
+	return "uv run", "uv"
+}
+
+// detectPyproject parses pyproject.toml for script entries.
+// Checks both [project.scripts] (PEP 621) and [tool.poetry.scripts] (Poetry).
+func detectPyproject(workDir string) []RunCommand {
+	path := filepath.Join(workDir, "pyproject.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	runner, label := detectPythonPackageManager(workDir)
+
+	// Script section headers to look for
+	scriptSections := []string{
+		"[project.scripts]",
+		"[tool.poetry.scripts]",
+	}
+
+	seen := make(map[string]bool)
+	var commands []RunCommand
+	content := string(data)
+
+	for _, section := range scriptSections {
+		parsed := parseTomlSection(content, section)
+		for _, name := range parsed {
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			commands = append(commands, RunCommand{
+				Name:    name,
+				Command: runner + " " + name,
+				Source:  label,
+				Group:   label,
+			})
+		}
+	}
+	return commands
+}
+
+// parseTomlSection extracts key names from a TOML section.
+// Returns sorted key names found under the given section header.
+func parseTomlSection(content string, sectionHeader string) []string {
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	inSection := false
+	var names []string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == sectionHeader {
+			inSection = true
+			continue
+		}
+
+		if inSection {
+			// New section starts
+			if strings.HasPrefix(trimmed, "[") {
+				break
+			}
+			// Parse "name = ..." lines
+			if strings.Contains(trimmed, "=") && !strings.HasPrefix(trimmed, "#") {
+				parts := strings.SplitN(trimmed, "=", 2)
+				name := strings.TrimSpace(parts[0])
+				if name != "" {
+					names = append(names, name)
+				}
+			}
+		}
+	}
+
+	sort.Strings(names)
+	return names
+}

--- a/internal/plugins/run/plugin.go
+++ b/internal/plugins/run/plugin.go
@@ -1,0 +1,145 @@
+package run
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/marcus/sidecar/internal/plugin"
+)
+
+const (
+	pluginID   = "run"
+	pluginName = "run"
+	pluginIcon = "R"
+
+	// Pane layout
+	dividerWidth = 1
+)
+
+// FocusPane represents which pane is active.
+type FocusPane int
+
+const (
+	PaneList   FocusPane = iota // Left sidebar (command list)
+	PaneOutput                  // Right pane (tmux output)
+)
+
+// Plugin implements the run command plugin.
+type Plugin struct {
+	ctx     *plugin.Context
+	focused bool
+	width   int
+	height  int
+
+	// Command state
+	commands []RunCommand // All available commands (detected + config)
+	cursor   int          // Selected command index
+	scrollOff int         // Scroll offset for command list
+
+	// Pane state
+	activePane   FocusPane
+	sidebarWidth int // Percentage width for sidebar
+
+	// Run session tracking
+	sessions map[int]*RunSession // Index → active session
+
+	// Output scroll state
+	outputScrollOff int
+	outputLines     int // Total lines in current output
+}
+
+// New creates a new run plugin.
+func New() *Plugin {
+	return &Plugin{
+		commands:     make([]RunCommand, 0),
+		sessions:     make(map[int]*RunSession),
+		activePane:   PaneList,
+		sidebarWidth: 30, // 30% sidebar
+	}
+}
+
+// ID returns the plugin identifier.
+func (p *Plugin) ID() string { return pluginID }
+
+// Name returns the plugin display name.
+func (p *Plugin) Name() string { return pluginName }
+
+// Icon returns the plugin icon.
+func (p *Plugin) Icon() string { return pluginIcon }
+
+// IsFocused returns whether the plugin is focused.
+func (p *Plugin) IsFocused() bool { return p.focused }
+
+// SetFocused sets the focus state.
+func (p *Plugin) SetFocused(f bool) { p.focused = f }
+
+// Init initializes the plugin with context.
+func (p *Plugin) Init(ctx *plugin.Context) error {
+	p.ctx = ctx
+	p.commands = nil
+	p.cursor = 0
+	p.scrollOff = 0
+	p.sessions = make(map[int]*RunSession)
+	p.outputScrollOff = 0
+	return nil
+}
+
+// Start begins async operations.
+func (p *Plugin) Start() tea.Cmd {
+	return p.detectCommandsCmd()
+}
+
+// Stop cleans up plugin resources.
+func (p *Plugin) Stop() {
+	// Kill all active tmux sessions
+	for _, session := range p.sessions {
+		if session != nil && session.SessionName != "" {
+			_ = stopRunSession(0, session.SessionName)
+		}
+	}
+	p.sessions = make(map[int]*RunSession)
+}
+
+// detectCommandsCmd runs auto-detection in the background.
+func (p *Plugin) detectCommandsCmd() tea.Cmd {
+	workDir := p.ctx.WorkDir
+	configCmds := p.getConfigCommands()
+	return func() tea.Msg {
+		detected := detectCommands(workDir)
+		// Merge config commands
+		all := append(detected, configCmds...)
+		return DetectCommandsMsg{Commands: all}
+	}
+}
+
+// getConfigCommands converts config commands to RunCommand structs.
+func (p *Plugin) getConfigCommands() []RunCommand {
+	if p.ctx == nil || p.ctx.Config == nil {
+		return nil
+	}
+	var commands []RunCommand
+	for _, cmd := range p.ctx.Config.Plugins.Run.Commands {
+		group := cmd.Group
+		if group == "" {
+			group = "config"
+		}
+		commands = append(commands, RunCommand{
+			Name:    cmd.Name,
+			Command: cmd.Command,
+			Source:  "config",
+			Group:   group,
+		})
+	}
+	return commands
+}
+
+// selectedCommand returns the currently selected command, or nil.
+func (p *Plugin) selectedCommand() *RunCommand {
+	if p.cursor < 0 || p.cursor >= len(p.commands) {
+		return nil
+	}
+	return &p.commands[p.cursor]
+}
+
+// selectedSession returns the session for the currently selected command.
+func (p *Plugin) selectedSession() *RunSession {
+	return p.sessions[p.cursor]
+}

--- a/internal/plugins/run/session.go
+++ b/internal/plugins/run/session.go
@@ -1,0 +1,160 @@
+package run
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+const (
+	sessionPrefix          = "sidecar-run-"
+	defaultCaptureMaxBytes = 2 * 1024 * 1024 // 2MB
+)
+
+// RunStatus represents the state of a running command.
+type RunStatus int
+
+const (
+	StatusIdle    RunStatus = iota // Not yet run
+	StatusRunning                  // Currently executing
+	StatusDone                     // Finished successfully
+	StatusError                    // Finished with error
+)
+
+// String returns a display label for the status.
+func (s RunStatus) String() string {
+	switch s {
+	case StatusRunning:
+		return "running"
+	case StatusDone:
+		return "done"
+	case StatusError:
+		return "error"
+	default:
+		return "idle"
+	}
+}
+
+// RunSession tracks a tmux session for a running command.
+type RunSession struct {
+	SessionName string
+	Command     RunCommand
+	Status      RunStatus
+	Output      string
+	StartedAt   time.Time
+}
+
+// Messages for run session lifecycle.
+type (
+	// RunSessionStartedMsg signals a command session was created and started.
+	RunSessionStartedMsg struct {
+		Index       int
+		SessionName string
+		Err         error
+	}
+
+	// RunOutputMsg carries captured output from a running session.
+	RunOutputMsg struct {
+		Index   int
+		Output  string
+		Changed bool
+	}
+
+	// RunSessionStoppedMsg signals a session was terminated.
+	RunSessionStoppedMsg struct {
+		Index int
+	}
+
+	// PollRunOutputMsg triggers a poll for command output.
+	PollRunOutputMsg struct {
+		Index int
+	}
+
+	// DetectCommandsMsg carries auto-detected commands.
+	DetectCommandsMsg struct {
+		Commands []RunCommand
+	}
+)
+
+// startRunSession creates a tmux session and runs the command.
+func startRunSession(idx int, cmd RunCommand, workDir string) tea.Cmd {
+	sessionName := fmt.Sprintf("%s%d", sessionPrefix, idx)
+
+	return func() tea.Msg {
+		// Kill any existing session with this name
+		_ = exec.Command("tmux", "kill-session", "-t", sessionName).Run()
+
+		// Create new detached session
+		args := []string{
+			"new-session",
+			"-d",
+			"-s", sessionName,
+			"-c", workDir,
+		}
+		createCmd := exec.Command("tmux", args...)
+		if err := createCmd.Run(); err != nil {
+			return RunSessionStartedMsg{
+				Index:       idx,
+				SessionName: sessionName,
+				Err:         fmt.Errorf("create session: %w", err),
+			}
+		}
+
+		// Send the command
+		sendCmd := exec.Command("tmux", "send-keys", "-t", sessionName, cmd.Command, "Enter")
+		if err := sendCmd.Run(); err != nil {
+			_ = exec.Command("tmux", "kill-session", "-t", sessionName).Run()
+			return RunSessionStartedMsg{
+				Index:       idx,
+				SessionName: sessionName,
+				Err:         fmt.Errorf("send command: %w", err),
+			}
+		}
+
+		return RunSessionStartedMsg{
+			Index:       idx,
+			SessionName: sessionName,
+		}
+	}
+}
+
+// captureRunOutput captures the pane output from a tmux session.
+func captureRunOutput(idx int, sessionName string) tea.Cmd {
+	return func() tea.Msg {
+		out, err := exec.Command("tmux", "capture-pane", "-t", sessionName, "-p", "-S", "-500").Output()
+		if err != nil {
+			// Session may have died
+			return RunOutputMsg{Index: idx, Output: "", Changed: false}
+		}
+
+		output := string(out)
+		// Trim trailing whitespace
+		output = strings.TrimRight(output, "\n ")
+
+		return RunOutputMsg{Index: idx, Output: output, Changed: true}
+	}
+}
+
+// stopRunSession kills a tmux session.
+func stopRunSession(idx int, sessionName string) tea.Cmd {
+	return func() tea.Msg {
+		_ = exec.Command("tmux", "kill-session", "-t", sessionName).Run()
+		return RunSessionStoppedMsg{Index: idx}
+	}
+}
+
+// schedulePoll schedules a poll for output after a delay.
+func schedulePoll(idx int, delay time.Duration) tea.Cmd {
+	return tea.Tick(delay, func(t time.Time) tea.Msg {
+		return PollRunOutputMsg{Index: idx}
+	})
+}
+
+// isSessionAlive checks if a tmux session exists.
+func isSessionAlive(sessionName string) bool {
+	err := exec.Command("tmux", "has-session", "-t", sessionName).Run()
+	return err == nil
+}

--- a/internal/plugins/run/update.go
+++ b/internal/plugins/run/update.go
@@ -1,0 +1,215 @@
+package run
+
+import (
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/marcus/sidecar/internal/plugin"
+)
+
+const (
+	pollInterval           = 500 * time.Millisecond
+	pollIntervalBackground = 2 * time.Second
+)
+
+// Update handles messages.
+func (p *Plugin) Update(msg tea.Msg) (plugin.Plugin, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		p.width = msg.Width
+		p.height = msg.Height
+
+	case DetectCommandsMsg:
+		p.commands = msg.Commands
+		if p.cursor >= len(p.commands) {
+			p.cursor = 0
+		}
+
+	case RunSessionStartedMsg:
+		if msg.Err != nil {
+			if p.ctx != nil && p.ctx.Logger != nil {
+				p.ctx.Logger.Error("run: session start failed", "error", msg.Err)
+			}
+			return p, nil
+		}
+		if msg.Index >= 0 && msg.Index < len(p.commands) {
+			p.sessions[msg.Index] = &RunSession{
+				SessionName: msg.SessionName,
+				Command:     p.commands[msg.Index],
+				Status:      StatusRunning,
+				StartedAt:   time.Now(),
+			}
+			// Start polling for output
+			return p, schedulePoll(msg.Index, pollInterval)
+		}
+
+	case RunOutputMsg:
+		session := p.sessions[msg.Index]
+		if session == nil {
+			return p, nil
+		}
+		session.Output = msg.Output
+		p.outputLines = len(strings.Split(msg.Output, "\n"))
+
+		// Check if session is still alive
+		if !isSessionAlive(session.SessionName) {
+			session.Status = StatusDone
+			return p, nil
+		}
+
+		// Schedule next poll
+		delay := pollInterval
+		if !p.focused {
+			delay = pollIntervalBackground
+		}
+		return p, schedulePoll(msg.Index, delay)
+
+	case PollRunOutputMsg:
+		session := p.sessions[msg.Index]
+		if session == nil || session.Status != StatusRunning {
+			return p, nil
+		}
+		return p, captureRunOutput(msg.Index, session.SessionName)
+
+	case RunSessionStoppedMsg:
+		if session, ok := p.sessions[msg.Index]; ok {
+			session.Status = StatusDone
+		}
+
+	case tea.KeyMsg:
+		return p.handleKey(msg)
+	}
+
+	return p, nil
+}
+
+// handleKey processes keyboard input.
+func (p *Plugin) handleKey(msg tea.KeyMsg) (plugin.Plugin, tea.Cmd) {
+	key := msg.String()
+
+	switch p.activePane {
+	case PaneList:
+		return p.handleListKey(key)
+	case PaneOutput:
+		return p.handleOutputKey(key)
+	}
+	return p, nil
+}
+
+// handleListKey handles keys when the command list is focused.
+func (p *Plugin) handleListKey(key string) (plugin.Plugin, tea.Cmd) {
+	switch key {
+	case "j", "down":
+		if p.cursor < len(p.commands)-1 {
+			p.cursor++
+			p.outputScrollOff = 0
+			p.ensureVisible()
+		}
+	case "k", "up":
+		if p.cursor > 0 {
+			p.cursor--
+			p.outputScrollOff = 0
+			p.ensureVisible()
+		}
+	case "g":
+		// Jump to top (simplified - no gg sequence for now)
+	case "G":
+		if len(p.commands) > 0 {
+			p.cursor = len(p.commands) - 1
+			p.outputScrollOff = 0
+			p.ensureVisible()
+		}
+	case "enter":
+		return p, p.runSelected()
+	case "x":
+		return p, p.stopSelected()
+	case "r":
+		return p, p.detectCommandsCmd()
+	case "tab":
+		if p.selectedSession() != nil {
+			p.activePane = PaneOutput
+		}
+	case "l", "right":
+		if p.selectedSession() != nil {
+			p.activePane = PaneOutput
+		}
+	}
+	return p, nil
+}
+
+// handleOutputKey handles keys when the output pane is focused.
+func (p *Plugin) handleOutputKey(key string) (plugin.Plugin, tea.Cmd) {
+	switch key {
+	case "tab", "h", "left", "esc":
+		p.activePane = PaneList
+	case "j", "down":
+		p.outputScrollOff++
+	case "k", "up":
+		if p.outputScrollOff > 0 {
+			p.outputScrollOff--
+		}
+	case "ctrl+d":
+		p.outputScrollOff += 10
+	case "ctrl+u":
+		if p.outputScrollOff > 10 {
+			p.outputScrollOff -= 10
+		} else {
+			p.outputScrollOff = 0
+		}
+	case "x":
+		return p, p.stopSelected()
+	}
+	return p, nil
+}
+
+// runSelected starts the currently selected command.
+func (p *Plugin) runSelected() tea.Cmd {
+	cmd := p.selectedCommand()
+	if cmd == nil {
+		return nil
+	}
+
+	// If already running, stop it first then restart
+	if session := p.selectedSession(); session != nil && session.Status == StatusRunning {
+		return tea.Sequence(
+			stopRunSession(p.cursor, session.SessionName),
+			startRunSession(p.cursor, *cmd, p.ctx.WorkDir),
+		)
+	}
+
+	return startRunSession(p.cursor, *cmd, p.ctx.WorkDir)
+}
+
+// stopSelected stops the currently running command.
+func (p *Plugin) stopSelected() tea.Cmd {
+	session := p.selectedSession()
+	if session == nil || session.Status != StatusRunning {
+		return nil
+	}
+	return stopRunSession(p.cursor, session.SessionName)
+}
+
+// ensureVisible adjusts scroll to keep selected item visible.
+func (p *Plugin) ensureVisible() {
+	if p.cursor < p.scrollOff {
+		p.scrollOff = p.cursor
+	}
+	visibleCount := p.listVisibleCount()
+	if visibleCount > 0 && p.cursor >= p.scrollOff+visibleCount {
+		p.scrollOff = p.cursor - visibleCount + 1
+	}
+	if p.scrollOff < 0 {
+		p.scrollOff = 0
+	}
+}
+
+// listVisibleCount returns how many list items fit in the sidebar.
+func (p *Plugin) listVisibleCount() int {
+	// height minus border (2) minus header (1)
+	count := p.height - 3
+	if count < 1 {
+		count = 1
+	}
+	return count
+}

--- a/internal/plugins/run/view.go
+++ b/internal/plugins/run/view.go
@@ -1,0 +1,322 @@
+package run
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/marcus/sidecar/internal/styles"
+	"github.com/marcus/sidecar/internal/ui"
+)
+
+// Status indicator symbols.
+const (
+	iconIdle    = "○"
+	iconRunning = "●"
+	iconDone    = "✓"
+	iconError   = "✗"
+)
+
+// View renders the plugin.
+func (p *Plugin) View(width, height int) string {
+	p.width = width
+	p.height = height
+
+	if len(p.commands) == 0 {
+		content := p.renderEmpty()
+		return lipgloss.NewStyle().Width(width).Height(height).MaxHeight(height).Render(content)
+	}
+
+	content := p.renderTwoPaneLayout(height)
+	return lipgloss.NewStyle().Width(width).Height(height).MaxHeight(height).Render(content)
+}
+
+// renderEmpty shows when no commands are detected.
+func (p *Plugin) renderEmpty() string {
+	var sb strings.Builder
+	sb.WriteString(styles.Title.Render("Run"))
+	sb.WriteString("\n\n")
+	sb.WriteString(styles.Muted.Render("No runnable commands detected."))
+	sb.WriteString("\n\n")
+	sb.WriteString(styles.Subtle.Render("Supports: Makefile, package.json, docker-compose.yml, pyproject.toml"))
+	sb.WriteString("\n")
+	sb.WriteString(styles.Subtle.Render("Or add commands to "))
+	sb.WriteString(styles.Code.Render("~/.config/sidecar/config.json"))
+	sb.WriteString(styles.Subtle.Render(" under "))
+	sb.WriteString(styles.Code.Render("plugins.run.commands"))
+	sb.WriteString("\n\n")
+	sb.WriteString(styles.Subtle.Render("Press "))
+	sb.WriteString(styles.Code.Render("r"))
+	sb.WriteString(styles.Subtle.Render(" to refresh"))
+	return sb.String()
+}
+
+// renderTwoPaneLayout renders the command list and output panes.
+func (p *Plugin) renderTwoPaneLayout(height int) string {
+	paneHeight := height
+	if paneHeight < 4 {
+		paneHeight = 4
+	}
+
+	innerHeight := paneHeight - 2
+	if innerHeight < 1 {
+		innerHeight = 1
+	}
+
+	// Calculate sidebar width
+	sidebarWidth := p.width * p.sidebarWidth / 100
+	if sidebarWidth < 20 {
+		sidebarWidth = 20
+	}
+	outputWidth := p.width - sidebarWidth - dividerWidth
+
+	listActive := p.activePane == PaneList
+	outputActive := p.activePane == PaneOutput
+
+	// Render pane contents
+	listContent := p.renderListPane(innerHeight, sidebarWidth-4) // -4 for borders+padding
+	outputContent := p.renderOutputPane(innerHeight, outputWidth-4)
+
+	// Apply panel styles
+	leftPane := styles.RenderPanel(listContent, sidebarWidth, paneHeight, listActive)
+	rightPane := styles.RenderPanel(outputContent, outputWidth, paneHeight, outputActive)
+
+	// Render divider
+	divider := ui.RenderDivider(paneHeight)
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, leftPane, divider, rightPane)
+}
+
+// renderListPane renders the command list sidebar.
+func (p *Plugin) renderListPane(height, contentWidth int) string {
+	var sb strings.Builder
+
+	// Header
+	sb.WriteString(styles.Title.Render("Commands"))
+	sb.WriteString(styles.Muted.Render(fmt.Sprintf(" (%d)", len(p.commands))))
+	sb.WriteString("\n")
+
+	headerLines := 1
+	listHeight := height - headerLines
+	if listHeight < 1 {
+		listHeight = 1
+	}
+
+	// Ensure cursor is visible
+	p.ensureVisibleForHeight(listHeight)
+
+	// Calculate visible range
+	start := p.scrollOff
+	end := start + listHeight
+	if end > len(p.commands) {
+		end = len(p.commands)
+	}
+
+	// Track current group for group headers
+	lastGroup := ""
+
+	for i := start; i < end; i++ {
+		cmd := p.commands[i]
+
+		// Group header
+		if cmd.Group != lastGroup {
+			lastGroup = cmd.Group
+			if i > start {
+				// Don't add group header if it would be the only line
+			}
+		}
+
+		isSelected := i == p.cursor
+		sb.WriteString(p.renderCommandRow(cmd, i, isSelected, contentWidth))
+		if i < end-1 {
+			sb.WriteString("\n")
+		}
+	}
+
+	return sb.String()
+}
+
+// renderCommandRow renders a single command row with status indicator.
+func (p *Plugin) renderCommandRow(cmd RunCommand, idx int, selected bool, maxWidth int) string {
+	// Status icon
+	icon := iconIdle
+	session := p.sessions[idx]
+	if session != nil {
+		switch session.Status {
+		case StatusRunning:
+			icon = iconRunning
+		case StatusDone:
+			icon = iconDone
+		case StatusError:
+			icon = iconError
+		}
+	}
+
+	// Build the row
+	var prefix string
+	if selected {
+		prefix = "> "
+	} else {
+		prefix = "  "
+	}
+
+	// Source tag
+	sourceTag := "[" + cmd.Source + "]"
+
+	// Calculate available width for name
+	nameWidth := maxWidth - len(prefix) - len(icon) - 1 - len(sourceTag) - 1
+	if nameWidth < 5 {
+		nameWidth = 5
+	}
+
+	name := cmd.Name
+	runes := []rune(name)
+	if len(runes) > nameWidth {
+		name = string(runes[:nameWidth-3]) + "..."
+	}
+
+	if selected {
+		// Full-width highlight for selected row
+		row := prefix + icon + " " + name
+		// Pad with spaces for source tag alignment
+		padding := maxWidth - lipgloss.Width(row) - len(sourceTag)
+		if padding > 0 {
+			row += strings.Repeat(" ", padding)
+		}
+		row += sourceTag
+		return styles.ListItemSelected.Render(row)
+	}
+
+	// Style based on status
+	var iconStyled string
+	if session != nil {
+		switch session.Status {
+		case StatusRunning:
+			iconStyled = styles.StatusModified.Render(icon)
+		case StatusDone:
+			iconStyled = styles.StatusStaged.Render(icon)
+		case StatusError:
+			iconStyled = styles.StatusDeleted.Render(icon)
+		default:
+			iconStyled = styles.Muted.Render(icon)
+		}
+	} else {
+		iconStyled = styles.Muted.Render(icon)
+	}
+
+	return prefix + iconStyled + " " + styles.Body.Render(name) + " " + styles.Muted.Render(sourceTag)
+}
+
+// renderOutputPane renders the right pane with command output.
+func (p *Plugin) renderOutputPane(height, contentWidth int) string {
+	session := p.selectedSession()
+	if session == nil {
+		return p.renderOutputPlaceholder()
+	}
+
+	var sb strings.Builder
+
+	// Header: command name and status
+	statusLabel := session.Status.String()
+	var statusStyled string
+	switch session.Status {
+	case StatusRunning:
+		statusStyled = styles.StatusModified.Render(statusLabel)
+	case StatusDone:
+		statusStyled = styles.StatusStaged.Render(statusLabel)
+	case StatusError:
+		statusStyled = styles.StatusDeleted.Render(statusLabel)
+	default:
+		statusStyled = styles.Muted.Render(statusLabel)
+	}
+
+	sb.WriteString(styles.Title.Render(session.Command.Name))
+	sb.WriteString(" ")
+	sb.WriteString(statusStyled)
+	sb.WriteString("\n")
+
+	// Command line
+	sb.WriteString(styles.Muted.Render("$ " + session.Command.Command))
+	sb.WriteString("\n")
+
+	headerLines := 2
+	outputHeight := height - headerLines
+	if outputHeight < 1 {
+		outputHeight = 1
+	}
+
+	// Render output with scroll
+	if session.Output == "" {
+		sb.WriteString(styles.Muted.Render("Waiting for output..."))
+	} else {
+		lines := strings.Split(session.Output, "\n")
+		p.outputLines = len(lines)
+
+		// Auto-scroll to bottom if not manually scrolled
+		maxScroll := len(lines) - outputHeight
+		if maxScroll < 0 {
+			maxScroll = 0
+		}
+		if p.outputScrollOff > maxScroll {
+			p.outputScrollOff = maxScroll
+		}
+
+		// For running commands, auto-scroll to bottom
+		if session.Status == StatusRunning && p.activePane != PaneOutput {
+			p.outputScrollOff = maxScroll
+		}
+
+		start := p.outputScrollOff
+		end := start + outputHeight
+		if end > len(lines) {
+			end = len(lines)
+		}
+		if start < 0 {
+			start = 0
+		}
+
+		for i := start; i < end; i++ {
+			line := lines[i]
+			// Truncate long lines
+			if lipgloss.Width(line) > contentWidth {
+				line = line[:contentWidth]
+			}
+			sb.WriteString(line)
+			if i < end-1 {
+				sb.WriteString("\n")
+			}
+		}
+	}
+
+	return sb.String()
+}
+
+// renderOutputPlaceholder shows when no command is selected or running.
+func (p *Plugin) renderOutputPlaceholder() string {
+	var sb strings.Builder
+	sb.WriteString(styles.Muted.Render("No output"))
+	sb.WriteString("\n\n")
+	sb.WriteString(styles.Subtle.Render("Select a command and press "))
+	sb.WriteString(styles.Code.Render("Enter"))
+	sb.WriteString(styles.Subtle.Render(" to run"))
+	return sb.String()
+}
+
+// ensureVisibleForHeight adjusts scroll offset for a given visible height.
+func (p *Plugin) ensureVisibleForHeight(visibleHeight int) {
+	if p.cursor < 0 {
+		p.cursor = 0
+	}
+	if len(p.commands) > 0 && p.cursor >= len(p.commands) {
+		p.cursor = len(p.commands) - 1
+	}
+	if p.cursor < p.scrollOff {
+		p.scrollOff = p.cursor
+	}
+	if p.cursor >= p.scrollOff+visibleHeight {
+		p.scrollOff = p.cursor - visibleHeight + 1
+	}
+	if p.scrollOff < 0 {
+		p.scrollOff = 0
+	}
+}


### PR DESCRIPTION
## Summary
- Add new "Run" tab plugin for discovering, executing, and monitoring project commands from within the TUI
- Auto-detects runnable targets from Makefile, package.json, docker-compose.yml, and pyproject.toml
- Smart package manager detection: npm/yarn/pnpm/bun (via lockfiles) and uv/poetry (via lockfiles)
- Two-pane layout with command list (left) and live tmux output (right)
- Supports manual commands via `plugins.run.commands` in sidecar config
- Gated behind `run_plugin` feature flag (default: false)

Fixes #140

## Test plan
- [ ] Enable feature flag: `sidecar features enable run_plugin` or set in config
- [ ] Verify commands are detected from Makefile, package.json, docker-compose.yml, pyproject.toml
- [ ] Verify correct package manager detected (yarn.lock → yarn, pnpm-lock.yaml → pnpm, etc.)
- [ ] Run a command with Enter, verify live output streams
- [ ] Stop a running command with x
- [ ] Tab between list and output panes
- [ ] Add manual commands to config and verify they appear
- [ ] Verify `go build ./...` and `go test ./...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)