### PR TITLE
fix: detect .todos file vs directory conflict in onboarding

### DIFF
--- a/internal/tdroot/tdroot.go
+++ b/internal/tdroot/tdroot.go
@@ -3,6 +3,7 @@
 package tdroot
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -76,6 +77,26 @@ func ResolveTDRoot(workDir string) string {
 func ResolveDBPath(workDir string) string {
 	root := ResolveTDRoot(workDir)
 	return filepath.Join(root, TodosDir, DBFile)
+}
+
+// ErrTodosIsFile is returned when .todos exists as a file instead of a directory.
+var ErrTodosIsFile = errors.New("found .todos file where a directory is expected")
+
+// CheckTodosConflict checks whether a .todos path exists as a regular file
+// instead of a directory. This can happen when an AI agent or other tool
+// creates a .todos file, conflicting with td's expected .todos directory.
+// Returns ErrTodosIsFile if there's a conflict, nil otherwise.
+func CheckTodosConflict(workDir string) error {
+	root := ResolveTDRoot(workDir)
+	todosPath := filepath.Join(root, TodosDir)
+	fi, err := os.Lstat(todosPath)
+	if err != nil {
+		return nil // doesn't exist — no conflict
+	}
+	if !fi.IsDir() {
+		return ErrTodosIsFile
+	}
+	return nil
 }
 
 // CreateTDRoot writes a .td-root file pointing to targetRoot.

--- a/internal/tdroot/tdroot_test.go
+++ b/internal/tdroot/tdroot_test.go
@@ -165,6 +165,81 @@ func TestCreateTDRoot_Overwrite(t *testing.T) {
 	}
 }
 
+func TestCheckTodosConflict_NoTodosPath(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "tdroot-conflict-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// No .todos at all — no conflict
+	if err := CheckTodosConflict(tmpDir); err != nil {
+		t.Errorf("expected nil error when .todos doesn't exist, got: %v", err)
+	}
+}
+
+func TestCheckTodosConflict_TodosIsDirectory(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "tdroot-conflict-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// .todos is a directory — no conflict
+	if err := os.MkdirAll(filepath.Join(tmpDir, TodosDir), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if err := CheckTodosConflict(tmpDir); err != nil {
+		t.Errorf("expected nil error when .todos is a directory, got: %v", err)
+	}
+}
+
+func TestCheckTodosConflict_TodosIsFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "tdroot-conflict-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// .todos is a regular file — conflict!
+	todosPath := filepath.Join(tmpDir, TodosDir)
+	if err := os.WriteFile(todosPath, []byte("not a directory"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	err = CheckTodosConflict(tmpDir)
+	if err == nil {
+		t.Fatal("expected error when .todos is a file, got nil")
+	}
+	if err != ErrTodosIsFile {
+		t.Errorf("expected ErrTodosIsFile, got: %v", err)
+	}
+}
+
+func TestCheckTodosConflict_TodosIsSymlink(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "tdroot-conflict-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// .todos is a symlink to a file — conflict (Lstat sees the symlink, not target)
+	targetFile := filepath.Join(tmpDir, "target")
+	if err := os.WriteFile(targetFile, []byte("data"), 0644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	todosPath := filepath.Join(tmpDir, TodosDir)
+	if err := os.Symlink(targetFile, todosPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	err = CheckTodosConflict(tmpDir)
+	if err == nil {
+		t.Fatal("expected error when .todos is a symlink to a file, got nil")
+	}
+}
+
 // --- helpers for worktree tests ---
 
 // initGitRepo creates a temp dir with a git repo containing one empty commit.


### PR DESCRIPTION
## Problem

When a `.todos` file (not directory) exists in a project, sidecar's onboarding silently fails — the setup dialog stays open, reinitializing in a loop, and clicking "Skip" shows "td is not installed" even though it is.

Root cause: An AI agent (or other tool) created a `.todos` file where sidecar expects a `.todos` directory for td's SQLite database.

## Fix

- Added `CheckTodosConflict()` in `tdroot` that uses `Lstat` to detect when `.todos` exists as a file or symlink-to-file instead of a directory
- Plugin `Init()` now checks for the conflict **before** attempting monitor creation
- `View()` renders a clear error with remediation instructions (`mv .todos .todos.bak && td init`)
- `Diagnostics()` reports the conflict as an error state
- `performSetup()` validates before calling `td init` instead of silently failing

## Tests

5 new tests covering: no .todos, directory exists, file exists, symlink, and full plugin integration.

Also fixes 2 pre-existing test failures in tdmonitor (`TestInitWithValidDatabase`, `TestDiagnosticsWithDatabase`).

Fixes #194