### PR TITLE
feat: add install script for binary downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,15 @@ Sidecar puts your entire development workflow in one shell: plan tasks with [td]
 
 ## Quick Install
 
-### macOS (recommended)
+### Script (recommended — no Go required)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/marcus/sidecar/main/install.sh | sh
+```
+
+Downloads the latest binary for your OS and architecture.
+
+### Homebrew (macOS)
 
 ```bash
 brew install marcus/tap/sidecar
@@ -22,11 +30,13 @@ brew install marcus/tap/sidecar
 
 This builds from source and avoids macOS Gatekeeper warnings.
 
-### Linux / Other
+### Interactive Setup
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/marcus/sidecar/main/scripts/setup.sh | bash
 ```
+
+Installs sidecar and optionally [td](https://github.com/marcus/td) with guided prompts.
 
 **More options:** [Binary downloads](https://github.com/marcus/sidecar/releases) · [Manual install](docs/getting-started.md)
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+set -eu
+
+# Sidecar install script — downloads a pre-built binary from GitHub Releases.
+# No Go required.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/marcus/sidecar/main/install.sh | sh
+
+REPO="marcus/sidecar"
+BINARY="sidecar"
+
+# Colors (disabled if not a terminal)
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[0;33m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BOLD=''
+    NC=''
+fi
+
+info() {
+    printf "${BOLD}%s${NC}\n" "$1"
+}
+
+success() {
+    printf "${GREEN}%s${NC}\n" "$1"
+}
+
+warn() {
+    printf "${YELLOW}%s${NC}\n" "$1"
+}
+
+error() {
+    printf "${RED}error: %s${NC}\n" "$1" >&2
+}
+
+die() {
+    error "$1"
+    exit 1
+}
+
+# --- Detect OS ---------------------------------------------------------------
+
+detect_os() {
+    case "$(uname -s)" in
+        Darwin) echo "darwin" ;;
+        Linux)  echo "linux" ;;
+        *)      die "Unsupported OS: $(uname -s). This installer supports macOS and Linux." ;;
+    esac
+}
+
+# --- Detect architecture -----------------------------------------------------
+
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64|amd64)   echo "amd64" ;;
+        aarch64|arm64)  echo "arm64" ;;
+        *)              die "Unsupported architecture: $(uname -m). This installer supports amd64 and arm64." ;;
+    esac
+}
+
+# --- Fetch latest release tag from GitHub API --------------------------------
+
+get_latest_version() {
+    local url="https://api.github.com/repos/${REPO}/releases/latest"
+    local tag
+
+    if command -v curl >/dev/null 2>&1; then
+        tag=$(curl -fsSL "$url" | grep '"tag_name"' | head -1 | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+    elif command -v wget >/dev/null 2>&1; then
+        tag=$(wget -qO- "$url" | grep '"tag_name"' | head -1 | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+    else
+        die "Neither curl nor wget found. Please install one and try again."
+    fi
+
+    if [ -z "$tag" ]; then
+        die "Could not determine the latest release. Check https://github.com/${REPO}/releases"
+    fi
+
+    echo "$tag"
+}
+
+# --- Download and extract ----------------------------------------------------
+
+download() {
+    local url="$1"
+    local dest="$2"
+
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$url" -o "$dest"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO "$dest" "$url"
+    fi
+}
+
+# --- Choose install directory ------------------------------------------------
+
+choose_install_dir() {
+    if [ -d "/usr/local/bin" ] && [ -w "/usr/local/bin" ]; then
+        echo "/usr/local/bin"
+    elif [ "$(id -u)" = "0" ]; then
+        echo "/usr/local/bin"
+    else
+        # No write access to /usr/local/bin and not root — try sudo, else fallback
+        if command -v sudo >/dev/null 2>&1; then
+            echo "/usr/local/bin"
+        else
+            mkdir -p "$HOME/.local/bin"
+            echo "$HOME/.local/bin"
+        fi
+    fi
+}
+
+# --- Main --------------------------------------------------------------------
+
+main() {
+    info "Sidecar Installer"
+    echo ""
+
+    OS=$(detect_os)
+    ARCH=$(detect_arch)
+    info "Detected: ${OS}/${ARCH}"
+
+    printf "Fetching latest release... "
+    VERSION=$(get_latest_version)
+    success "$VERSION"
+
+    # Build download URL: sidecar_0.74.1_darwin_arm64.tar.gz
+    VER_NUM="${VERSION#v}"
+    ARCHIVE="${BINARY}_${VER_NUM}_${OS}_${ARCH}.tar.gz"
+    URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE}"
+
+    INSTALL_DIR=$(choose_install_dir)
+    NEEDS_SUDO=false
+    if [ ! -w "$INSTALL_DIR" ] && [ "$(id -u)" != "0" ]; then
+        NEEDS_SUDO=true
+    fi
+
+    TMPDIR=$(mktemp -d)
+    trap 'rm -rf "$TMPDIR"' EXIT
+
+    printf "Downloading %s... " "$ARCHIVE"
+    if ! download "$URL" "$TMPDIR/$ARCHIVE"; then
+        echo ""
+        die "Download failed. Check that ${URL} exists."
+    fi
+    success "done"
+
+    printf "Extracting... "
+    if ! tar -xzf "$TMPDIR/$ARCHIVE" -C "$TMPDIR" 2>/dev/null; then
+        die "Failed to extract archive."
+    fi
+
+    if [ ! -f "$TMPDIR/$BINARY" ]; then
+        die "Binary '${BINARY}' not found in archive."
+    fi
+    success "done"
+
+    printf "Installing to %s... " "$INSTALL_DIR"
+    if [ "$NEEDS_SUDO" = true ]; then
+        sudo install -m 755 "$TMPDIR/$BINARY" "$INSTALL_DIR/$BINARY"
+    else
+        install -m 755 "$TMPDIR/$BINARY" "$INSTALL_DIR/$BINARY"
+    fi
+    success "done"
+
+    # Verify
+    echo ""
+    if command -v "$BINARY" >/dev/null 2>&1; then
+        INSTALLED_VERSION=$("$BINARY" --version 2>/dev/null || echo "unknown")
+        success "sidecar ${INSTALLED_VERSION} installed successfully!"
+    elif [ -x "$INSTALL_DIR/$BINARY" ]; then
+        INSTALLED_VERSION=$("$INSTALL_DIR/$BINARY" --version 2>/dev/null || echo "unknown")
+        success "sidecar ${INSTALLED_VERSION} installed to ${INSTALL_DIR}"
+        echo ""
+        warn "Note: ${INSTALL_DIR} is not in your PATH."
+        echo "Add it with:"
+        echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+    else
+        die "Installation failed — binary not found after install."
+    fi
+
+    echo ""
+    echo "Run 'sidecar' in any project directory to get started."
+}
+
+main


### PR DESCRIPTION
## Summary
- Add `install.sh` at repo root that downloads pre-built binaries from GitHub Releases — no Go required
- Detects OS (darwin/linux) and architecture (amd64/arm64), fetches latest release tag from GitHub API, downloads and extracts the correct tarball, installs to `/usr/local/bin` (with sudo if needed) or `~/.local/bin` as fallback
- Update README.md to add `curl | sh` as the recommended Quick Install method, above Homebrew

Fixes #134

## Test plan
- [ ] Run `curl -fsSL .../install.sh | sh` on macOS arm64
- [ ] Run on macOS amd64 (or verify correct archive URL is constructed)
- [ ] Run on Linux amd64/arm64
- [ ] Verify fallback to `~/.local/bin` when `/usr/local/bin` is not writable and sudo is unavailable
- [ ] Verify `sidecar --version` outputs expected version after install
- [ ] Verify README renders correctly with new install sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)