### PR TITLE
fix: add all sidecar state files to .gitignore on init and startup

### DIFF
--- a/internal/plugins/gitstatus/no_repo.go
+++ b/internal/plugins/gitstatus/no_repo.go
@@ -12,8 +12,19 @@ import (
 	"github.com/marcus/sidecar/internal/styles"
 )
 
-var initRepoGitignoreEntries = []string{
+// sidecarGitignoreEntries lists all sidecar state paths that should be ignored
+// by git. These are added both when initializing a new repository and when
+// sidecar first opens an existing repository, ensuring worktree operations
+// never produce unexpected git noise.
+var sidecarGitignoreEntries = []string{
 	".todos/",
+	".sidecar/",
+	".sidecar-agent",
+	".sidecar-task",
+	".sidecar-pr",
+	".sidecar-start.sh",
+	".sidecar-base",
+	".td-root",
 }
 
 // RepoDetectedMsg is sent after probing for a repository in the current workdir.
@@ -94,7 +105,7 @@ func (p *Plugin) initRepo() tea.Cmd {
 			return RepoInitDoneMsg{Epoch: epoch, Err: fmt.Errorf("git init succeeded but repository was not detected: %w", err)}
 		}
 
-		if err := ensureGitignoreEntries(workDir, initRepoGitignoreEntries); err != nil {
+		if err := ensureGitignoreEntries(workDir, sidecarGitignoreEntries); err != nil {
 			return RepoInitDoneMsg{Epoch: epoch, Root: root, Err: err}
 		}
 

--- a/internal/plugins/gitstatus/no_repo_test.go
+++ b/internal/plugins/gitstatus/no_repo_test.go
@@ -72,10 +72,10 @@ func TestEnsureGitignoreEntries_AddAndIdempotent(t *testing.T) {
 		t.Fatalf("write .gitignore: %v", err)
 	}
 
-	if err := ensureGitignoreEntries(tmp, []string{".todos/", ".sidecar/"}); err != nil {
+	if err := ensureGitignoreEntries(tmp, sidecarGitignoreEntries); err != nil {
 		t.Fatalf("ensureGitignoreEntries() first call error = %v", err)
 	}
-	if err := ensureGitignoreEntries(tmp, []string{".todos/", ".sidecar/"}); err != nil {
+	if err := ensureGitignoreEntries(tmp, sidecarGitignoreEntries); err != nil {
 		t.Fatalf("ensureGitignoreEntries() second call error = %v", err)
 	}
 
@@ -84,11 +84,86 @@ func TestEnsureGitignoreEntries_AddAndIdempotent(t *testing.T) {
 		t.Fatalf("read .gitignore: %v", err)
 	}
 	content := string(data)
-	if strings.Count(content, ".todos/") != 1 {
-		t.Fatalf(".todos/ count = %d, want 1", strings.Count(content, ".todos/"))
+	for _, entry := range sidecarGitignoreEntries {
+		if strings.Count(content, entry) != 1 {
+			t.Fatalf("%q count = %d, want 1\ncontent:\n%s", entry, strings.Count(content, entry), content)
+		}
 	}
-	if strings.Count(content, ".sidecar/") != 1 {
-		t.Fatalf(".sidecar/ count = %d, want 1", strings.Count(content, ".sidecar/"))
+}
+
+func TestEnsureGitignoreEntries_AllSidecarEntries(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Verify all expected sidecar state paths are covered
+	expected := []string{
+		".todos/",
+		".sidecar/",
+		".sidecar-agent",
+		".sidecar-task",
+		".sidecar-pr",
+		".sidecar-start.sh",
+		".sidecar-base",
+		".td-root",
+	}
+	for _, e := range expected {
+		found := false
+		for _, s := range sidecarGitignoreEntries {
+			if s == e {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("sidecarGitignoreEntries missing expected entry %q", e)
+		}
+	}
+
+	// Ensure entries are applied cleanly to an empty .gitignore
+	if err := ensureGitignoreEntries(tmp, sidecarGitignoreEntries); err != nil {
+		t.Fatalf("ensureGitignoreEntries() error = %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	content := string(data)
+	for _, entry := range expected {
+		if !strings.Contains(content, entry) {
+			t.Errorf(".gitignore missing entry %q\ncontent:\n%s", entry, content)
+		}
+	}
+}
+
+func TestStart_EnsuresGitignoreForExistingRepo(t *testing.T) {
+	repoDir := t.TempDir()
+	initCmd := exec.Command("git", "init")
+	initCmd.Dir = repoDir
+	if out, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v (%s)", err, strings.TrimSpace(string(out)))
+	}
+
+	// Write a .gitignore that deliberately omits sidecar entries
+	gitignore := filepath.Join(repoDir, ".gitignore")
+	if err := os.WriteFile(gitignore, []byte("node_modules/\n"), 0644); err != nil {
+		t.Fatalf("write .gitignore: %v", err)
+	}
+
+	p := New()
+	if err := p.Init(&plugin.Context{WorkDir: repoDir}); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	// Call Start() synchronously — we only care about the side-effect (gitignore update)
+	_ = p.Start()
+
+	data, err := os.ReadFile(gitignore)
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	content := string(data)
+	for _, entry := range sidecarGitignoreEntries {
+		if !strings.Contains(content, entry) {
+			t.Errorf("after Start(), .gitignore missing entry %q\ncontent:\n%s", entry, content)
+		}
 	}
 }
 

--- a/internal/plugins/gitstatus/plugin.go
+++ b/internal/plugins/gitstatus/plugin.go
@@ -310,6 +310,10 @@ func (p *Plugin) Start() tea.Cmd {
 	if !p.hasRepo {
 		return nil
 	}
+	// Ensure all sidecar state paths are in .gitignore on every startup.
+	// This is intentionally best-effort: failures are non-fatal since the
+	// project already has a repo and the user can still work.
+	_ = ensureGitignoreEntries(p.repoRoot, sidecarGitignoreEntries)
 	return tea.Batch(
 		p.refresh(),
 		p.startWatcher(),


### PR DESCRIPTION
## Problem

When sidecar ran for the first time against an existing repo, the `.gitignore` was never updated. For new repos (via `git init` in sidecar), only `.todos/` was added. This meant sidecar state files appeared as untracked files before the first worktree was created.

Fixes #201

## Solution

Option 1 from the issue: add all sidecar entries unconditionally.

### Changes

- **`sidecarGitignoreEntries`** — renamed from `initRepoGitignoreEntries` and expanded to cover all sidecar state paths:
  ```
  .todos/
  .sidecar/
  .sidecar-agent
  .sidecar-task
  .sidecar-pr
  .sidecar-start.sh
  .sidecar-base
  .td-root
  ```
- **`Start()` in gitstatus plugin** — calls `ensureGitignoreEntries` for existing repos on every startup. The call is idempotent (only appends missing entries) and best-effort (errors are non-fatal).
- **Tests** — new `TestEnsureGitignoreEntries_AllSidecarEntries` validates the full entry list; `TestStart_EnsuresGitignoreForExistingRepo` validates the existing-repo path.

## Testing

```
go build ./cmd/sidecar/
go test ./...
```

All pass.