### PR TITLE
fix: remove stale sessionIndex references in opencode adapter tests

### DIFF
--- a/internal/adapter/opencode/adapter_test.go
+++ b/internal/adapter/opencode/adapter_test.go
@@ -146,7 +146,6 @@ func TestFindProjectID_WithSandboxPaths(t *testing.T) {
 	a := &Adapter{
 		storageDir:   tmpDir,
 		projectIndex: make(map[string]*Project),
-		sessionIndex: make(map[string]string),
 		metaCache:    make(map[string]sessionMetaCacheEntry),
 	}
 
@@ -208,7 +207,6 @@ func TestFindProjectID_SubdirectoryMatch(t *testing.T) {
 	a := &Adapter{
 		storageDir:   tmpDir,
 		projectIndex: make(map[string]*Project),
-		sessionIndex: make(map[string]string),
 		metaCache:    make(map[string]sessionMetaCacheEntry),
 	}
 
@@ -266,7 +264,6 @@ func TestFindProjectID_SandboxNotDuplicated(t *testing.T) {
 	a := &Adapter{
 		storageDir:   tmpDir,
 		projectIndex: make(map[string]*Project),
-		sessionIndex: make(map[string]string),
 		metaCache:    make(map[string]sessionMetaCacheEntry),
 	}
 


### PR DESCRIPTION
The `sessionIndex` field was removed from the `Adapter` struct as dead code, but three test struct literals still referenced it (lines 149, 211, 269), causing CI to fail.

This removes those stale field references. All tests pass.