### PR TITLE
fix: resolve CI lint and test failures

### DIFF
--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -182,7 +182,7 @@ func copyFile(src, dst string, mode fs.FileMode) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer func() { _ = in.Close() }()
 
 	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_EXCL, mode&0777)
 	if err != nil {
@@ -191,7 +191,7 @@ func copyFile(src, dst string, mode fs.FileMode) error {
 		}
 		return err
 	}
-	defer out.Close()
+	defer func() { _ = out.Close() }()
 
 	if _, err := io.Copy(out, in); err != nil {
 		_ = os.Remove(dst) // Clean up partial write.

--- a/internal/plugins/workspace/agent_test.go
+++ b/internal/plugins/workspace/agent_test.go
@@ -924,7 +924,7 @@ func TestWriteAgentLauncher(t *testing.T) {
 			agentType: AgentAmp,
 			baseCmd:   "amp --dangerously-allow-all",
 			prompt:    "Task: fix bug",
-			wantCmd:   "bash '" + tmpDir + "/.sidecar-start.sh'",
+			wantCmd:   "bash '" + expectedLauncherPath + "'",
 		},
 	}
 

--- a/internal/plugins/workspace/update.go
+++ b/internal/plugins/workspace/update.go
@@ -97,7 +97,7 @@ func (p *Plugin) Update(msg tea.Msg) (plugin.Plugin, tea.Cmd) {
 						wtPaths = append(wtPaths, wt.Path)
 					}
 				}
-				go migration.MigrateProject(p.ctx.ProjectRoot, wtPaths)
+				go func() { _ = migration.MigrateProject(p.ctx.ProjectRoot, wtPaths) }()
 			}
 
 			// Bounds check in case the selected worktree was deleted


### PR DESCRIPTION
Fixes CI failures on main:

**Lint (errcheck):**
- `internal/migration/migration.go:185` — wrap `defer in.Close()` with `_ =`
- `internal/migration/migration.go:194` — wrap `defer out.Close()` with `_ =`
- `internal/plugins/workspace/update.go:100` — wrap `migration.MigrateProject()` goroutine with `_ =`

**Test:**
- `TestWriteAgentLauncher/amp_pipes_via_stdin` — update expected path from old `.sidecar-start.sh` to new state directory path