### PR TITLE
dev: add pre-commit hooks for gofmt/vet/build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,3 +103,9 @@ build-all:
 # Test GoReleaser locally (creates snapshot build without publishing)
 goreleaser-snapshot:
 	goreleaser release --snapshot --clean
+
+# Install pre-commit hooks
+install-hooks:
+	@chmod +x scripts/pre-commit.sh
+	@ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit
+	@echo "✅ pre-commit hook installed"

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ make fmt-check    # Verify formatting for changed Go files
 make fmt-check-all # Verify formatting across full codebase
 make lint         # Lint new issues only (merge-base with main)
 make lint-all     # Lint entire codebase (includes legacy debt)
+make install-hooks # Install pre-commit hooks (gofmt, go vet, go build)
 ```
 
 ### Go Lint Baseline

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# pre-commit hook for sidecar
+# Install: make install-hooks  (or: ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit)
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+echo "🪡 pre-commit checks"
+
+# --- gofmt: only staged .go files ---
+STAGED_GO=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$' || true)
+
+if [[ -n "$STAGED_GO" ]]; then
+  printf "  %-20s" "gofmt"
+  UNFORMATTED=$(echo "$STAGED_GO" | xargs gofmt -l 2>&1)
+  if [[ -z "$UNFORMATTED" ]]; then
+    echo "✓"
+    PASS=$((PASS+1))
+  else
+    echo "✗ FAILED — run: gofmt -w ."
+    echo "$UNFORMATTED" | sed 's/^/    /'
+    FAIL=$((FAIL+1))
+  fi
+else
+  printf "  %-20s" "gofmt"
+  echo "– (no .go files staged)"
+fi
+
+# --- go vet ---
+printf "  %-20s" "go vet"
+VET_OUT=$(go vet ./... 2>&1)
+if [[ $? -eq 0 ]]; then
+  echo "✓"
+  PASS=$((PASS+1))
+else
+  echo "✗ FAILED"
+  echo "$VET_OUT" | sed 's/^/    /'
+  FAIL=$((FAIL+1))
+fi
+
+# --- go build ---
+printf "  %-20s" "go build"
+BUILD_OUT=$(go build ./... 2>&1)
+if [[ $? -eq 0 ]]; then
+  echo "✓"
+  PASS=$((PASS+1))
+else
+  echo "✗ FAILED"
+  echo "$BUILD_OUT" | sed 's/^/    /'
+  FAIL=$((FAIL+1))
+fi
+
+echo ""
+if [[ $FAIL -gt 0 ]]; then
+  echo "❌ $FAIL check(s) failed. Fix issues or use --no-verify to skip."
+  exit 1
+else
+  echo "✅ All checks passed ($PASS)"
+fi


### PR DESCRIPTION
Adds `scripts/pre-commit.sh` that runs gofmt (staged files only), go vet, and go build on commit.

Install with:
```
make install-hooks
```

Mirrors the pattern landed in nightshift #44.