### PR TITLE
fix: resolve worktree path from ProjectRoot, not WorkDir (#174)

### DIFF
--- a/internal/plugins/workspace/fetch_pr.go
+++ b/internal/plugins/workspace/fetch_pr.go
@@ -66,7 +66,13 @@ func (p *Plugin) fetchAndCreateWorktree(pr PRListItem) tea.Cmd {
 				dirName = repoName + "-" + branch
 			}
 		}
-		parentDir := filepath.Dir(workDir)
+		// Use projectRoot (the main worktree) rather than workDir so that
+		// starting from a subfolder doesn't place the worktree inside the repo. Fixes #174.
+		mainRepoDir := projectRoot
+		if mainRepoDir == "" {
+			mainRepoDir = workDir
+		}
+		parentDir := filepath.Dir(mainRepoDir)
 		wtPath := filepath.Join(parentDir, dirName)
 
 		// Create worktree tracking the remote branch

--- a/internal/plugins/workspace/worktree.go
+++ b/internal/plugins/workspace/worktree.go
@@ -274,8 +274,15 @@ func (p *Plugin) doCreateWorktree(name, baseBranch, taskID, taskTitle string, ag
 		}
 	}
 
-	// Determine worktree path (sibling to main repo)
-	parentDir := filepath.Dir(p.ctx.WorkDir)
+	// Determine worktree path (sibling to main repo).
+	// Use ProjectRoot (the main worktree path, resolved from git) rather than
+	// WorkDir so that starting sidecar from a subfolder doesn't place the new
+	// worktree inside the repository instead of beside it. Fixes #174.
+	mainRepoDir := p.ctx.ProjectRoot
+	if mainRepoDir == "" {
+		mainRepoDir = p.ctx.WorkDir
+	}
+	parentDir := filepath.Dir(mainRepoDir)
 	wtPath := filepath.Join(parentDir, dirName)
 
 	// Ensure parent directory exists for paths with slashes (e.g., feat/ui)


### PR DESCRIPTION
## Problem

When sidecar is started from a **subfolder** of a git repo (e.g. `cd myrepo/src && sidecar`), `WorkDir` is set to that subfolder. Both `doCreateWorktree` (worktree.go) and `fetchAndCreateWorktree` (fetch_pr.go) computed the new worktree's parent as `filepath.Dir(WorkDir)`, which resolves to the **git root itself** — placing the new worktree *inside* the main repo instead of beside it.

This caused `git worktree add` to fail with `fatal: invalid reference: <branch>: exit status 128` because the path conflicted with existing repo contents.

## Fix

Use `ProjectRoot` (already correctly resolved to the main worktree path via `GetMainWorktreePath` in main.go) as the anchor for the parent-dir calculation. Falls back to `WorkDir` if `ProjectRoot` is empty.

**Before (broken when started from subfolder):**
```
WorkDir   = /repos/myrepo/subfolder
parentDir = /repos/myrepo        ← git root, not its parent!
wtPath    = /repos/myrepo/feat   ← INSIDE the main repo
```

**After (fixed):**
```
ProjectRoot = /repos/myrepo
parentDir   = /repos             ← parent of main repo ✓
wtPath      = /repos/feat        ← sibling of main repo ✓
```

## Testing

- All existing tests pass (`go test ./...`)
- Added `TestWorktreePathResolvesFromProjectRoot` regression test

Fixes #174