### PR TITLE
fix: restore mobile sidebar nav visibility

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -2095,6 +2095,11 @@ a:hover {
   flex-direction: column !important;
 }
 
+/* Override Infima's translateX slide animation — we use display:none/flex via [inert] instead */
+.navbar-sidebar__items--show-secondary {
+  transform: none !important;
+}
+
 /* Toggle between primary and secondary menus on docs pages */
 .navbar-sidebar__item[inert] {
   display: none !important;


### PR DESCRIPTION
## Problem

On mobile, the hamburger menu opened but the sidebar appeared completely empty — no doc links visible.

## Root Cause

The custom CSS in `custom.css` changed `.navbar-sidebar__items` to use `flex-direction: column` (stacking the primary and secondary panels vertically). However, Infima's default CSS for `.navbar-sidebar__items--show-secondary` still applied `transform: translateX(-83vw)` — designed for the default horizontal side-by-side layout to slide between panels.

With `flex-direction: column`, this horizontal translate moved the entire items container off the left edge of the sidebar, making all content invisible.

## Fix

Add `.navbar-sidebar__items--show-secondary { transform: none !important; }` to cancel the slide. The `[inert]` attribute + `display: none/flex` CSS already handles showing/hiding the correct panel — no slide animation needed.

## Testing

Verified with Playwright on iPhone 12 viewport: doc links now appear correctly in the mobile sidebar.