### PR TITLE
feat(workspace): add "Start in plan mode" checkbox to create modal

### DIFF
--- a/internal/plugins/workspace/agent.go
+++ b/internal/plugins/workspace/agent.go
@@ -423,14 +423,21 @@ func getAgentCommand(agentType AgentType) string {
 	return "claude" // Default to claude
 }
 
-// buildAgentCommand builds the agent command with optional skip permissions and task context.
+// buildAgentCommand builds the agent command with optional skip permissions, plan mode, and task context.
 // If there's task context, it writes a launcher script to avoid shell escaping issues.
-func (p *Plugin) buildAgentCommand(agentType AgentType, wt *Worktree, skipPerms bool, prompt *Prompt) string {
+func (p *Plugin) buildAgentCommand(agentType AgentType, wt *Worktree, skipPerms bool, planMode bool, prompt *Prompt) string {
 	baseCmd := getAgentCommand(agentType)
 
 	// Apply skip permissions flag if requested
 	if skipPerms {
 		if flag := SkipPermissionsFlags[agentType]; flag != "" {
+			baseCmd = baseCmd + " " + flag
+		}
+	}
+
+	// Apply plan mode flag if requested
+	if planMode {
+		if flag := PlanModeFlags[agentType]; flag != "" {
 			baseCmd = baseCmd + " " + flag
 		}
 	}
@@ -541,12 +548,12 @@ rm -f %q
 
 // getAgentCommandWithContext returns the agent command with optional task context (legacy, no skip perms).
 func (p *Plugin) getAgentCommandWithContext(agentType AgentType, wt *Worktree) string {
-	return p.buildAgentCommand(agentType, wt, false, nil)
+	return p.buildAgentCommand(agentType, wt, false, false, nil)
 }
 
 // StartAgentWithOptions creates a tmux session and starts an agent with options.
 // If a session already exists, it reconnects to it instead of failing.
-func (p *Plugin) StartAgentWithOptions(wt *Worktree, agentType AgentType, skipPerms bool, prompt *Prompt) tea.Cmd {
+func (p *Plugin) StartAgentWithOptions(wt *Worktree, agentType AgentType, skipPerms bool, planMode bool, prompt *Prompt) tea.Cmd {
 	epoch := p.ctx.Epoch // Capture epoch for stale detection
 	return func() tea.Msg {
 		sessionName := tmuxSessionPrefix + sanitizeName(wt.Name)
@@ -602,8 +609,8 @@ func (p *Plugin) StartAgentWithOptions(wt *Worktree, agentType AgentType, skipPe
 		// Small delay to ensure env is set
 		time.Sleep(100 * time.Millisecond)
 
-		// Build the agent command with skip permissions and prompt if enabled
-		agentCmd := p.buildAgentCommand(agentType, wt, skipPerms, prompt)
+		// Build the agent command with skip permissions, plan mode, and prompt if enabled
+		agentCmd := p.buildAgentCommand(agentType, wt, skipPerms, planMode, prompt)
 
 		// Send the agent command to start it
 		sendCmd := exec.Command("tmux", "send-keys", "-t", sessionName, agentCmd, "Enter")

--- a/internal/plugins/workspace/agent_test.go
+++ b/internal/plugins/workspace/agent_test.go
@@ -610,7 +610,7 @@ func TestBuildAgentCommand(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			wt := &Worktree{TaskID: tt.taskID}
-			result := p.buildAgentCommand(tt.agentType, wt, tt.skipPerms, nil)
+			result := p.buildAgentCommand(tt.agentType, wt, tt.skipPerms, false, nil)
 
 			// Check base command
 			baseCmd := getAgentCommand(tt.agentType)
@@ -668,7 +668,7 @@ func TestBuildAgentCommandSyntax(t *testing.T) {
 		}
 		t.Run(name, func(t *testing.T) {
 			wt := &Worktree{TaskID: ""} // No task context
-			result := p.buildAgentCommand(tt.agentType, wt, tt.skipPerms, nil)
+			result := p.buildAgentCommand(tt.agentType, wt, tt.skipPerms, false, nil)
 			if result != tt.expected {
 				t.Errorf("buildAgentCommand(%s, skipPerms=%v) = %q, want %q",
 					tt.agentType, tt.skipPerms, result, tt.expected)

--- a/internal/plugins/workspace/create_modal.go
+++ b/internal/plugins/workspace/create_modal.go
@@ -12,17 +12,18 @@ import (
 )
 
 const (
-	createNameFieldID           = "create-name"
-	createBaseFieldID           = "create-base"
-	createPromptFieldID         = "create-prompt"
-	createTaskFieldID           = "create-task"
-	createAgentListID           = "create-agent-list"
-	createSkipPermissionsID     = "create-skip-permissions"
-	createSubmitID              = "create-submit"
-	createCancelID              = "create-cancel"
-	createBranchItemPrefix      = "create-branch-"
-	createTaskItemPrefix        = "create-task-item-"
-	createAgentItemPrefix       = "create-agent-"
+	createNameFieldID       = "create-name"
+	createBaseFieldID       = "create-base"
+	createPromptFieldID     = "create-prompt"
+	createTaskFieldID       = "create-task"
+	createAgentListID       = "create-agent-list"
+	createSkipPermissionsID = "create-skip-permissions"
+	createPlanModeID        = "create-plan-mode"
+	createSubmitID          = "create-submit"
+	createCancelID          = "create-cancel"
+	createBranchItemPrefix  = "create-branch-"
+	createTaskItemPrefix    = "create-task-item-"
+	createAgentItemPrefix   = "create-agent-"
 )
 
 func createIndexedID(prefix string, idx int) string {
@@ -85,6 +86,8 @@ func (p *Plugin) ensureCreateModal() {
 		AddSection(p.createSkipPermissionsSpacerSection()).
 		AddSection(modal.When(p.shouldShowSkipPermissions, modal.Checkbox(createSkipPermissionsID, "Auto-approve all actions", &p.createSkipPermissions))).
 		AddSection(p.createSkipPermissionsHintSection()).
+		AddSection(modal.When(p.shouldShowPlanMode, modal.Checkbox(createPlanModeID, "Start in plan mode", &p.createPlanMode))).
+		AddSection(p.createPlanModeHintSection()).
 		AddSection(modal.Spacer()).
 		AddSection(p.createErrorSection()).
 		AddSection(modal.When(func() bool { return p.createError != "" }, modal.Spacer())).
@@ -114,7 +117,7 @@ func (p *Plugin) normalizeCreateFocus() {
 		}
 	}
 	if p.createFocus == 5 && !p.shouldShowSkipPermissions() {
-		p.createFocus = 6
+		p.createFocus = 7 // Skip both checkboxes
 	}
 }
 
@@ -143,8 +146,10 @@ func (p *Plugin) createFocusID() string {
 	case 5:
 		return createSkipPermissionsID
 	case 6:
-		return createSubmitID
+		return createPlanModeID
 	case 7:
+		return createSubmitID
+	case 8:
 		return createCancelID
 	default:
 		return ""
@@ -481,6 +486,24 @@ func (p *Plugin) createSkipPermissionsHintSection() modal.Section {
 			return modal.RenderedSection{Content: dimText(fmt.Sprintf("      (Adds %s)", flag))}
 		}
 		return modal.RenderedSection{Content: dimText("  Skip permissions not available for this agent")}
+	}, nil)
+}
+
+// shouldShowPlanMode returns true if the current agent type supports plan mode.
+func (p *Plugin) shouldShowPlanMode() bool {
+	if p.createAgentType == AgentNone {
+		return false
+	}
+	return PlanModeFlags[p.createAgentType] != ""
+}
+
+func (p *Plugin) createPlanModeHintSection() modal.Section {
+	return modal.Custom(func(contentWidth int, focusID, hoverID string) modal.RenderedSection {
+		if !p.shouldShowPlanMode() {
+			return modal.RenderedSection{}
+		}
+		flag := PlanModeFlags[p.createAgentType]
+		return modal.RenderedSection{Content: dimText(fmt.Sprintf("      (Adds %s)", flag))}
 	}, nil)
 }
 

--- a/internal/plugins/workspace/keys.go
+++ b/internal/plugins/workspace/keys.go
@@ -920,7 +920,7 @@ func (p *Plugin) handleListKeys(msg tea.KeyMsg) tea.Cmd {
 }
 
 // handleCreateKeys handles keys in create modal.
-// createFocus: 0=name, 1=base, 2=prompt, 3=task, 4=agent, 5=skipPerms, 6=create button, 7=cancel button
+// createFocus: 0=name, 1=base, 2=prompt, 3=task, 4=agent, 5=skipPerms, 6=planMode, 7=create button, 8=cancel button
 func (p *Plugin) handleCreateKeys(msg tea.KeyMsg) tea.Cmd {
 	p.ensureCreateModal()
 	if p.createModal == nil {
@@ -936,15 +936,21 @@ func (p *Plugin) handleCreateKeys(msg tea.KeyMsg) tea.Cmd {
 		return nil
 	case "tab":
 		p.blurCreateInputs()
-		p.createFocus = (p.createFocus + 1) % 8
+		p.createFocus = (p.createFocus + 1) % 9
 		p.normalizeCreateFocus()
+		if p.createFocus == 6 {
+			p.createFocus = 7 // Skip planMode in tab cycle
+		}
 		p.focusCreateInput()
 		p.syncCreateModalFocus()
 		return nil
 	case "shift+tab":
 		p.blurCreateInputs()
-		p.createFocus = (p.createFocus + 7) % 8
+		p.createFocus = (p.createFocus + 8) % 9
 		p.normalizeCreateFocus()
+		if p.createFocus == 6 {
+			p.createFocus = 5 // Skip planMode in shift+tab cycle
+		}
 		p.focusCreateInput()
 		p.syncCreateModalFocus()
 		return nil
@@ -964,6 +970,10 @@ func (p *Plugin) handleCreateKeys(msg tea.KeyMsg) tea.Cmd {
 			p.createSkipPermissions = !p.createSkipPermissions
 			return nil
 		}
+		if p.createFocus == 6 {
+			p.createPlanMode = !p.createPlanMode
+			return nil
+		}
 	case "up":
 		if p.createFocus == 1 && len(p.branchFiltered) > 0 {
 			if p.branchIdx > 0 {
@@ -977,6 +987,11 @@ func (p *Plugin) handleCreateKeys(msg tea.KeyMsg) tea.Cmd {
 			}
 			return nil
 		}
+		if p.createFocus == 6 {
+			p.createFocus = 5
+			p.syncCreateModalFocus()
+			return nil
+		}
 	case "down":
 		if p.createFocus == 1 && len(p.branchFiltered) > 0 {
 			if p.branchIdx < len(p.branchFiltered)-1 {
@@ -988,6 +1003,11 @@ func (p *Plugin) handleCreateKeys(msg tea.KeyMsg) tea.Cmd {
 			if p.taskSearchIdx < len(p.taskSearchFiltered)-1 {
 				p.taskSearchIdx++
 			}
+			return nil
+		}
+		if p.createFocus == 5 && p.shouldShowPlanMode() {
+			p.createFocus = 6
+			p.syncCreateModalFocus()
 			return nil
 		}
 	case "enter":
@@ -1043,10 +1063,10 @@ func (p *Plugin) handleCreateKeys(msg tea.KeyMsg) tea.Cmd {
 			p.syncCreateModalFocus()
 			return nil
 		}
-		if p.createFocus == 6 {
+		if p.createFocus == 7 {
 			return p.validateAndCreateWorktree()
 		}
-		if p.createFocus == 7 {
+		if p.createFocus == 8 {
 			p.viewMode = ViewModeList
 			p.clearCreateModal()
 			return nil
@@ -1143,7 +1163,7 @@ func (p *Plugin) blurCreateInputs() {
 }
 
 // focusCreateInput focuses the appropriate textinput based on createFocus.
-// createFocus: 0=name, 1=base, 2=prompt (no textinput), 3=task, 4+=non-inputs
+// createFocus: 0=name, 1=base, 2=prompt (no textinput), 3=task, 4+=non-inputs (agent, checkboxes, buttons)
 func (p *Plugin) focusCreateInput() {
 	switch p.createFocus {
 	case 0:

--- a/internal/plugins/workspace/messages.go
+++ b/internal/plugins/workspace/messages.go
@@ -98,6 +98,7 @@ type CreateDoneMsg struct {
 	Worktree  *Worktree
 	AgentType AgentType // Agent selected at creation
 	SkipPerms bool      // Whether to skip permissions
+	PlanMode  bool      // Whether to start in plan mode
 	Prompt    *Prompt   // Selected prompt template (nil if none)
 	Err       error
 }

--- a/internal/plugins/workspace/mouse.go
+++ b/internal/plugins/workspace/mouse.go
@@ -142,6 +142,11 @@ func (p *Plugin) handleCreateModalMouse(msg tea.MouseMsg) tea.Cmd {
 		p.createSkipPermissions = !p.createSkipPermissions
 		p.syncCreateModalFocus()
 		return nil
+	case createPlanModeID:
+		p.createFocus = 6
+		p.createPlanMode = !p.createPlanMode
+		p.syncCreateModalFocus()
+		return nil
 	}
 
 	if idx, ok := parseIndexedID(createBranchItemPrefix, action); ok && idx < len(p.branchFiltered) {
@@ -663,9 +668,9 @@ func (p *Plugin) handleMouseClick(action mouse.MouseAction) tea.Cmd {
 		// Click on button
 		if idx, ok := action.Region.Data.(int); ok {
 			switch idx {
-			case 6:
-				return p.createWorktree()
 			case 7:
+				return p.createWorktree()
+			case 8:
 				p.viewMode = ViewModeList
 				p.clearCreateModal()
 			}

--- a/internal/plugins/workspace/plugin.go
+++ b/internal/plugins/workspace/plugin.go
@@ -182,7 +182,8 @@ type Plugin struct {
 	createAgentType       AgentType // Selected agent type (default: AgentClaude)
 	createAgentIdx        int       // Selected agent index in AgentTypeOrder
 	createSkipPermissions bool      // Skip permissions checkbox
-	createFocus           int       // 0=name, 1=base, 2=prompt, 3=task, 4=agent, 5=skipPerms, 6=create, 7=cancel
+	createPlanMode        bool      // Start in plan mode checkbox
+	createFocus           int       // 0=name, 1=base, 2=prompt, 3=task, 4=agent, 5=skipPerms, 6=planMode, 7=create, 8=cancel
 	createButtonHover     int       // 0=none, 1=create, 2=cancel
 	createError           string    // Error message to display in create modal
 	createModal           *modal.Modal
@@ -723,6 +724,7 @@ func (p *Plugin) clearCreateModal() {
 	p.createAgentType = AgentClaude // Default to Claude
 	p.createAgentIdx = p.agentTypeIndex(p.createAgentType)
 	p.createSkipPermissions = false
+	p.createPlanMode = false
 	p.createFocus = 0
 	p.createError = ""
 	p.createModal = nil
@@ -775,6 +777,7 @@ func (p *Plugin) initCreateModalBase() {
 	p.createAgentType = AgentClaude
 	p.createAgentIdx = p.agentTypeIndex(p.createAgentType)
 	p.createSkipPermissions = false
+	p.createPlanMode = false
 	p.createFocus = 0
 	p.createError = ""
 	p.createModal = nil

--- a/internal/plugins/workspace/types.go
+++ b/internal/plugins/workspace/types.go
@@ -146,6 +146,11 @@ var SkipPermissionsFlags = map[AgentType]string{
 	AgentAmp:      "--dangerously-allow-all",
 }
 
+// PlanModeFlags maps agent types to their plan-mode CLI flags.
+var PlanModeFlags = map[AgentType]string{
+	AgentClaude: "--permission-mode=plan",
+}
+
 // AgentDisplayNames provides human-readable names for agent types.
 var AgentDisplayNames = map[AgentType]string{
 	AgentNone:     "None (attach only)",

--- a/internal/plugins/workspace/update.go
+++ b/internal/plugins/workspace/update.go
@@ -207,7 +207,7 @@ func (p *Plugin) Update(msg tea.Msg) (plugin.Plugin, tea.Cmd) {
 
 			// Start agent or attach based on selection
 			if msg.AgentType != AgentNone && msg.AgentType != "" {
-				cmds = append(cmds, p.StartAgentWithOptions(msg.Worktree, msg.AgentType, msg.SkipPerms, msg.Prompt))
+				cmds = append(cmds, p.StartAgentWithOptions(msg.Worktree, msg.AgentType, msg.SkipPerms, msg.PlanMode, msg.Prompt))
 			} else {
 				// "None" selected - attach to worktree directory
 				cmds = append(cmds, p.AttachToWorktreeDir(msg.Worktree))

--- a/internal/plugins/workspace/worktree.go
+++ b/internal/plugins/workspace/worktree.go
@@ -236,11 +236,12 @@ func (p *Plugin) createWorktree() tea.Cmd {
 	taskTitle := p.createTaskTitle
 	agentType := p.createAgentType
 	skipPerms := p.createSkipPermissions
+	planMode := p.createPlanMode
 	prompt := p.getSelectedPrompt()
 
 	// Debug log to trace taskID flow
 	if p.ctx != nil && p.ctx.Logger != nil {
-		p.ctx.Logger.Debug("createWorktree: captured modal state", "name", name, "taskID", taskID, "taskTitle", taskTitle, "agentType", agentType, "skipPerms", skipPerms, "hasPrompt", prompt != nil)
+		p.ctx.Logger.Debug("createWorktree: captured modal state", "name", name, "taskID", taskID, "taskTitle", taskTitle, "agentType", agentType, "skipPerms", skipPerms, "planMode", planMode, "hasPrompt", prompt != nil)
 	}
 
 	if name == "" {
@@ -251,7 +252,7 @@ func (p *Plugin) createWorktree() tea.Cmd {
 
 	return func() tea.Msg {
 		wt, err := p.doCreateWorktree(name, baseBranch, taskID, taskTitle, agentType)
-		return CreateDoneMsg{Worktree: wt, AgentType: agentType, SkipPerms: skipPerms, Prompt: prompt, Err: err}
+		return CreateDoneMsg{Worktree: wt, AgentType: agentType, SkipPerms: skipPerms, PlanMode: planMode, Prompt: prompt, Err: err}
 	}
 }
 


### PR DESCRIPTION
Adds a "Start in plan mode" checkbox below "Auto-approve all actions" in the Create New Worktree modal. When checked, passes --permission-mode=plan to Claude Code on startup.

- Only shown for Claude Code (the only agent with a plan mode flag)
- Tab cycle unchanged: agent → auto-approve → Create button
- Arrow keys navigate between the two checkboxes
- Mouse click supported as usual