### PR TITLE
fix: escape single quotes for bash 3.2 in start scripts

### DIFF
--- a/internal/plugins/workspace/agent.go
+++ b/internal/plugins/workspace/agent.go
@@ -498,22 +498,22 @@ fi
 		// aider uses --message flag
 		script = fmt.Sprintf(`#!/bin/bash
 %s
-%s --message "$(cat <<'SIDECAR_PROMPT_EOF'
+read -r -d '' sidecar_prompt <<'SIDECAR_PROMPT_EOF'
 %s
 SIDECAR_PROMPT_EOF
-)"
+%s --message "$sidecar_prompt"
 rm -f %q
-`, shellSetup, baseCmd, prompt, launcherFile)
+`, shellSetup, prompt, baseCmd, launcherFile)
 	case AgentOpenCode:
 		// opencode uses 'run' subcommand
 		script = fmt.Sprintf(`#!/bin/bash
 %s
-%s run "$(cat <<'SIDECAR_PROMPT_EOF'
+read -r -d '' sidecar_prompt <<'SIDECAR_PROMPT_EOF'
 %s
 SIDECAR_PROMPT_EOF
-)"
+%s run "$sidecar_prompt"
 rm -f %q
-`, shellSetup, baseCmd, prompt, launcherFile)
+`, shellSetup, prompt, baseCmd, launcherFile)
 	case AgentAmp:
 		// amp requires piping via stdin, does not accept positional args
 		script = fmt.Sprintf(`#!/bin/bash
@@ -527,12 +527,12 @@ rm -f %q
 		// Most agents (claude, codex, gemini, cursor) take prompt as positional argument
 		script = fmt.Sprintf(`#!/bin/bash
 %s
-%s "$(cat <<'SIDECAR_PROMPT_EOF'
+read -r -d '' sidecar_prompt <<'SIDECAR_PROMPT_EOF'
 %s
 SIDECAR_PROMPT_EOF
-)"
+%s "$sidecar_prompt"
 rm -f %q
-`, shellSetup, baseCmd, prompt, launcherFile)
+`, shellSetup, prompt, baseCmd, launcherFile)
 	}
 
 	if err := os.WriteFile(launcherFile, []byte(script), 0700); err != nil {


### PR DESCRIPTION
When a task description contains a single quote, the current pattern
`claude "$(cat <<'SIDECAR_PROMPT_EOF' ...` fails on macOS with the
error:

```
/path/to/start.sh: line 16: unexpected EOF while looking for matching `''
/path/to/start.sh: line 22: syntax error: unexpected end of file
```

macOS ships with bash 3.2 which contains a bug that parses the current
pattern incorrectly. 

To ensure the script works on macOS, use `read` to read the heredoc into
a variable first, then use the variable when launching the agent.

Before:

```sh
claude "$(cat <<'SIDECAR_PROMPT_EOF'
This single quote causes the bash error: '
SIDECAR_PROMPT_EOF
)"
```

After:

```sh
read -r -d '' sidecar_prompt <<'SIDECAR_PROMPT_EOF'
This single quote is now okay: '
SIDECAR_PROMPT_EOF
claude "$sidecar_prompt"
```
