### PR TITLE
feat: add Goose conversation adapter and workspace agent option

### DIFF
--- a/cmd/sidecar/main.go
+++ b/cmd/sidecar/main.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/marcus/sidecar/internal/adapter/copilot"
 	_ "github.com/marcus/sidecar/internal/adapter/cursor"
 	_ "github.com/marcus/sidecar/internal/adapter/geminicli"
+	_ "github.com/marcus/sidecar/internal/adapter/goose"
 	_ "github.com/marcus/sidecar/internal/adapter/kiro"
 	_ "github.com/marcus/sidecar/internal/adapter/opencode"
 	_ "github.com/marcus/sidecar/internal/adapter/pi"

--- a/internal/adapter/goose/adapter.go
+++ b/internal/adapter/goose/adapter.go
@@ -1,0 +1,961 @@
+package goose
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/marcus/sidecar/internal/adapter"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+const (
+	adapterID    = "goose"
+	adapterName  = "Goose"
+	queryTimeout = 5 * time.Second
+	msgCacheMax  = 128
+)
+
+// Adapter implements the adapter.Adapter interface for Goose sessions.
+type Adapter struct {
+	dbPath string
+	db     *sql.DB
+	dbMu   sync.Mutex
+	msgMu  sync.Mutex
+	msgMap map[string]messageCacheEntry
+}
+
+// New creates a new Goose adapter.
+func New() *Adapter {
+	home, _ := os.UserHomeDir()
+	return &Adapter{
+		dbPath: findGooseDB(home),
+		msgMap: make(map[string]messageCacheEntry),
+	}
+}
+
+// ID returns the adapter identifier.
+func (a *Adapter) ID() string { return adapterID }
+
+// Name returns the human-readable adapter name.
+func (a *Adapter) Name() string { return adapterName }
+
+// Icon returns the adapter icon for badge display.
+func (a *Adapter) Icon() string { return "G" }
+
+// Capabilities returns the supported features.
+func (a *Adapter) Capabilities() adapter.CapabilitySet {
+	return adapter.CapabilitySet{
+		adapter.CapSessions: true,
+		adapter.CapMessages: true,
+		adapter.CapUsage:    true,
+		adapter.CapWatch:    true,
+	}
+}
+
+// WatchScope returns Global because Goose uses one global SQLite DB.
+func (a *Adapter) WatchScope() adapter.WatchScope {
+	return adapter.WatchScopeGlobal
+}
+
+// Detect checks whether Goose sessions exist for the given project root.
+func (a *Adapter) Detect(projectRoot string) (bool, error) {
+	if _, err := os.Stat(a.dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	db, err := a.getDB()
+	if err != nil {
+		return false, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+
+	rows, err := db.QueryContext(ctx, `SELECT DISTINCT working_dir FROM sessions`)
+	if err != nil {
+		return false, nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var workDir string
+		if err := rows.Scan(&workDir); err != nil {
+			continue
+		}
+		if cwdMatchesProject(projectRoot, workDir) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// Sessions returns sessions for the given project, sorted by update time desc.
+func (a *Adapter) Sessions(projectRoot string) ([]adapter.Session, error) {
+	db, err := a.getDB()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT
+			s.id,
+			s.name,
+			s.description,
+			s.session_type,
+			s.working_dir,
+			s.created_at,
+			s.updated_at,
+			s.total_tokens,
+			s.input_tokens,
+			s.output_tokens,
+			s.accumulated_total_tokens,
+			s.accumulated_input_tokens,
+			s.accumulated_output_tokens,
+			COUNT(m.id) as message_count
+		FROM sessions s
+		LEFT JOIN messages m ON m.session_id = s.id
+		GROUP BY
+			s.id, s.name, s.description, s.session_type, s.working_dir,
+			s.created_at, s.updated_at, s.total_tokens, s.input_tokens, s.output_tokens,
+			s.accumulated_total_tokens, s.accumulated_input_tokens, s.accumulated_output_tokens
+		ORDER BY updated_at DESC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	sessions := make([]adapter.Session, 0)
+	dbSize := sqliteStorageSize(a.dbPath)
+	for rows.Next() {
+		var (
+			id                string
+			name              string
+			description       string
+			sessionType       string
+			workingDir        string
+			createdAtRaw      string
+			updatedAtRaw      string
+			totalTokens       sql.NullInt64
+			inputTokens       sql.NullInt64
+			outputTokens      sql.NullInt64
+			accumTotalTokens  sql.NullInt64
+			accumInputTokens  sql.NullInt64
+			accumOutputTokens sql.NullInt64
+			messageCount      int
+		)
+
+		if err := rows.Scan(
+			&id,
+			&name,
+			&description,
+			&sessionType,
+			&workingDir,
+			&createdAtRaw,
+			&updatedAtRaw,
+			&totalTokens,
+			&inputTokens,
+			&outputTokens,
+			&accumTotalTokens,
+			&accumInputTokens,
+			&accumOutputTokens,
+			&messageCount,
+		); err != nil {
+			continue
+		}
+
+		if !cwdMatchesProject(projectRoot, workingDir) {
+			continue
+		}
+
+		createdAt := parseSQLiteTime(createdAtRaw)
+		updatedAt := parseSQLiteTime(updatedAtRaw)
+		if createdAt.IsZero() {
+			createdAt = updatedAt
+		}
+
+		sessionName := strings.TrimSpace(name)
+		if sessionName == "" {
+			sessionName = strings.TrimSpace(description)
+		}
+		if sessionName == "" {
+			sessionName = shortConversationID(id)
+		}
+
+		tokTotal := chooseInt(accumTotalTokens, totalTokens)
+		inTok := chooseInt(accumInputTokens, inputTokens)
+		outTok := chooseInt(accumOutputTokens, outputTokens)
+		if tokTotal == 0 {
+			tokTotal = inTok + outTok
+		}
+
+		sessions = append(sessions, adapter.Session{
+			ID:              id,
+			Name:            sessionName,
+			Slug:            shortConversationID(id),
+			AdapterID:       adapterID,
+			AdapterName:     adapterName,
+			AdapterIcon:     a.Icon(),
+			CreatedAt:       createdAt,
+			UpdatedAt:       updatedAt,
+			Duration:        updatedAt.Sub(createdAt),
+			IsActive:        time.Since(updatedAt) < 5*time.Minute,
+			TotalTokens:     tokTotal,
+			MessageCount:    messageCount,
+			FileSize:        dbSize,
+			SessionCategory: toSessionCategory(sessionType),
+		})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].UpdatedAt.After(sessions[j].UpdatedAt)
+	})
+
+	return sessions, nil
+}
+
+// SessionByID returns one session without scanning all sessions.
+func (a *Adapter) SessionByID(sessionID string) (*adapter.Session, error) {
+	db, err := a.getDB()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+
+	row := db.QueryRowContext(ctx, `
+		SELECT
+			s.id,
+			s.name,
+			s.description,
+			s.session_type,
+			s.created_at,
+			s.updated_at,
+			s.total_tokens,
+			s.input_tokens,
+			s.output_tokens,
+			s.accumulated_total_tokens,
+			s.accumulated_input_tokens,
+			s.accumulated_output_tokens,
+			COUNT(m.id) as message_count
+		FROM sessions s
+		LEFT JOIN messages m ON m.session_id = s.id
+		WHERE s.id = ?
+		GROUP BY
+			s.id, s.name, s.description, s.session_type, s.created_at, s.updated_at,
+			s.total_tokens, s.input_tokens, s.output_tokens,
+			s.accumulated_total_tokens, s.accumulated_input_tokens, s.accumulated_output_tokens
+		LIMIT 1
+	`, sessionID)
+
+	var (
+		id                string
+		name              string
+		description       string
+		sessionType       string
+		createdAtRaw      string
+		updatedAtRaw      string
+		totalTokens       sql.NullInt64
+		inputTokens       sql.NullInt64
+		outputTokens      sql.NullInt64
+		accumTotalTokens  sql.NullInt64
+		accumInputTokens  sql.NullInt64
+		accumOutputTokens sql.NullInt64
+		messageCount      int
+	)
+	if err := row.Scan(
+		&id,
+		&name,
+		&description,
+		&sessionType,
+		&createdAtRaw,
+		&updatedAtRaw,
+		&totalTokens,
+		&inputTokens,
+		&outputTokens,
+		&accumTotalTokens,
+		&accumInputTokens,
+		&accumOutputTokens,
+		&messageCount,
+	); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("session %s not found", sessionID)
+		}
+		return nil, err
+	}
+
+	createdAt := parseSQLiteTime(createdAtRaw)
+	updatedAt := parseSQLiteTime(updatedAtRaw)
+	if createdAt.IsZero() {
+		createdAt = updatedAt
+	}
+
+	sessionName := strings.TrimSpace(name)
+	if sessionName == "" {
+		sessionName = strings.TrimSpace(description)
+	}
+	if sessionName == "" {
+		sessionName = shortConversationID(id)
+	}
+
+	tokTotal := chooseInt(accumTotalTokens, totalTokens)
+	inTok := chooseInt(accumInputTokens, inputTokens)
+	outTok := chooseInt(accumOutputTokens, outputTokens)
+	if tokTotal == 0 {
+		tokTotal = inTok + outTok
+	}
+
+	return &adapter.Session{
+		ID:              id,
+		Name:            sessionName,
+		Slug:            shortConversationID(id),
+		AdapterID:       adapterID,
+		AdapterName:     adapterName,
+		AdapterIcon:     a.Icon(),
+		CreatedAt:       createdAt,
+		UpdatedAt:       updatedAt,
+		Duration:        updatedAt.Sub(createdAt),
+		IsActive:        time.Since(updatedAt) < 5*time.Minute,
+		TotalTokens:     tokTotal,
+		MessageCount:    messageCount,
+		FileSize:        sqliteStorageSize(a.dbPath),
+		SessionCategory: toSessionCategory(sessionType),
+	}, nil
+}
+
+// Messages returns all messages for a Goose session.
+func (a *Adapter) Messages(sessionID string) ([]adapter.Message, error) {
+	db, err := a.getDB()
+	if err != nil {
+		return nil, err
+	}
+
+	a.ensureCache()
+
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+
+	sig, err := a.messageSignature(ctx, db, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if sig.count == 0 {
+		return nil, nil
+	}
+
+	a.msgMu.Lock()
+	if cached, ok := a.msgMap[sessionID]; ok && cached.sig == sig {
+		cached.lastAccess = time.Now()
+		a.msgMap[sessionID] = cached
+		msgs := copyMessages(cached.messages)
+		a.msgMu.Unlock()
+		return msgs, nil
+	}
+	a.msgMu.Unlock()
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT message_id, role, content_json, created_timestamp, timestamp, metadata_json
+		FROM messages
+		WHERE session_id = ?
+		ORDER BY created_timestamp, id
+	`, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	messages := make([]adapter.Message, 0)
+	toolRefs := make(map[string]toolUseRef)
+
+	idx := 0
+	for rows.Next() {
+		var (
+			messageID        sql.NullString
+			role             string
+			contentJSON      string
+			createdTimestamp sql.NullInt64
+			timestampRaw     string
+			metadataJSON     sql.NullString
+		)
+		if err := rows.Scan(&messageID, &role, &contentJSON, &createdTimestamp, &timestampRaw, &metadataJSON); err != nil {
+			return nil, err
+		}
+
+		blocks, err := parseGooseBlocks(contentJSON)
+		if err != nil {
+			return nil, fmt.Errorf("parse goose message %q: %w", messageID.String, err)
+		}
+
+		msgID := messageID.String
+		if msgID == "" {
+			msgID = fmt.Sprintf("%s:%d", sessionID, idx)
+		}
+
+		ts := time.Time{}
+		if createdTimestamp.Valid {
+			ts = time.Unix(createdTimestamp.Int64, 0)
+		}
+		if ts.IsZero() {
+			ts = parseSQLiteTime(timestampRaw)
+		}
+
+		contentParts := make([]string, 0)
+		contentBlocks := make([]adapter.ContentBlock, 0)
+		thinkingBlocks := make([]adapter.ThinkingBlock, 0)
+		toolUses := make([]adapter.ToolUse, 0)
+		currentToolIdx := make(map[string]int)
+
+		for _, b := range blocks {
+			switch strings.ToLower(b.Type) {
+			case "text":
+				text := strings.TrimSpace(b.Text)
+				if text == "" {
+					continue
+				}
+				contentParts = append(contentParts, text)
+				contentBlocks = append(contentBlocks, adapter.ContentBlock{Type: "text", Text: text})
+
+			case "thinking", "reasoning":
+				text := strings.TrimSpace(b.Thinking)
+				if text == "" {
+					text = strings.TrimSpace(b.Text)
+				}
+				if text == "" {
+					continue
+				}
+				thinkingBlocks = append(thinkingBlocks, adapter.ThinkingBlock{
+					Content:    text,
+					TokenCount: maxInt(1, len(text)/4),
+				})
+				contentBlocks = append(contentBlocks, adapter.ContentBlock{Type: "thinking", Text: text, TokenCount: maxInt(1, len(text)/4)})
+
+			case "toolrequest", "frontendtoolrequest":
+				useID := b.ID
+				if useID == "" {
+					useID = fmt.Sprintf("tool_%s_%d", msgID, len(toolUses))
+				}
+				toolName, toolInput := parseToolCall(b.ToolCall)
+				if toolName == "" {
+					toolName = "tool"
+				}
+				toolUses = append(toolUses, adapter.ToolUse{ID: useID, Name: toolName, Input: toolInput})
+				toolRef := toolUseRef{msgIdx: len(messages), toolIdx: len(toolUses) - 1}
+				toolRefs[useID] = toolRef
+				currentToolIdx[useID] = len(toolUses) - 1
+				contentBlocks = append(contentBlocks, adapter.ContentBlock{
+					Type:      "tool_use",
+					ToolUseID: useID,
+					ToolName:  toolName,
+					ToolInput: toolInput,
+				})
+				if toolName != "" {
+					contentParts = append(contentParts, "[Tool: "+toolName+"]")
+				}
+
+			case "toolresponse":
+				useID := b.ID
+				output, isErr := parseToolResult(b.ToolResult)
+				contentBlocks = append(contentBlocks, adapter.ContentBlock{
+					Type:       "tool_result",
+					ToolUseID:  useID,
+					ToolOutput: output,
+					IsError:    isErr,
+				})
+				if output != "" {
+					contentParts = append(contentParts, "[Tool Result] "+output)
+				}
+				if idx, ok := currentToolIdx[useID]; ok && idx < len(toolUses) {
+					toolUses[idx].Output = output
+				}
+				if ref, ok := toolRefs[useID]; ok && ref.msgIdx < len(messages) && ref.toolIdx < len(messages[ref.msgIdx].ToolUses) {
+					messages[ref.msgIdx].ToolUses[ref.toolIdx].Output = output
+					messages[ref.msgIdx].ContentBlocks = append(messages[ref.msgIdx].ContentBlocks, adapter.ContentBlock{
+						Type:       "tool_result",
+						ToolUseID:  useID,
+						ToolOutput: output,
+						IsError:    isErr,
+					})
+				}
+			}
+		}
+
+		if len(contentParts) == 0 && len(contentBlocks) == 0 {
+			continue
+		}
+
+		model := ""
+		if metadataJSON.Valid {
+			model = extractModelFromMetadata(metadataJSON.String)
+		}
+
+		messages = append(messages, adapter.Message{
+			ID:             msgID,
+			Role:           normalizeRole(role),
+			Content:        strings.Join(contentParts, "\n"),
+			Timestamp:      ts,
+			Model:          model,
+			ToolUses:       toolUses,
+			ThinkingBlocks: thinkingBlocks,
+			ContentBlocks:  contentBlocks,
+		})
+		idx++
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	a.msgMu.Lock()
+	a.msgMap[sessionID] = messageCacheEntry{
+		sig:        sig,
+		messages:   copyMessages(messages),
+		lastAccess: time.Now(),
+	}
+	a.evictCacheLocked()
+	a.msgMu.Unlock()
+
+	return messages, nil
+}
+
+// Usage returns aggregate usage stats for a session.
+func (a *Adapter) Usage(sessionID string) (*adapter.UsageStats, error) {
+	db, err := a.getDB()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+
+	query := `
+		SELECT
+			COALESCE(accumulated_input_tokens, input_tokens, 0),
+			COALESCE(accumulated_output_tokens, output_tokens, 0),
+			(SELECT COUNT(*) FROM messages WHERE session_id = ?)
+		FROM sessions
+		WHERE id = ?
+		LIMIT 1
+	`
+
+	var inTok, outTok, msgCount int
+	err = db.QueryRowContext(ctx, query, sessionID, sessionID).Scan(&inTok, &outTok, &msgCount)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &adapter.UsageStats{
+		TotalInputTokens:  inTok,
+		TotalOutputTokens: outTok,
+		MessageCount:      msgCount,
+	}, nil
+}
+
+// Watch watches Goose DB and WAL changes.
+func (a *Adapter) Watch(projectRoot string) (<-chan adapter.Event, io.Closer, error) {
+	if _, err := os.Stat(a.dbPath); err != nil {
+		return nil, nil, err
+	}
+	src, closer, err := NewWatcher(a.dbPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	out := make(chan adapter.Event, 32)
+	go func() {
+		defer close(out)
+		for evt := range src {
+			if evt.SessionID == "" {
+				if id, err := a.latestChangedSessionID(); err == nil {
+					evt.SessionID = id
+				}
+			}
+			select {
+			case out <- evt:
+			default:
+			}
+		}
+	}()
+	return out, closer, nil
+}
+
+func (a *Adapter) getDB() (*sql.DB, error) {
+	a.dbMu.Lock()
+	defer a.dbMu.Unlock()
+
+	if a.db != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+		err := a.db.PingContext(ctx)
+		cancel()
+		if err == nil {
+			return a.db, nil
+		}
+		_ = a.db.Close()
+		a.db = nil
+	}
+
+	connStr := a.dbPath + "?mode=ro&_journal_mode=WAL"
+	db, err := sql.Open("sqlite3", connStr)
+	if err != nil {
+		return nil, err
+	}
+
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(0)
+	db.SetConnMaxLifetime(time.Minute)
+
+	a.db = db
+	return a.db, nil
+}
+
+func findGooseDB(home string) string {
+	candidates := gooseDBCandidates(home)
+	for _, p := range candidates {
+		if info, err := os.Stat(p); err == nil && !info.IsDir() {
+			return p
+		}
+	}
+	if len(candidates) > 0 {
+		return candidates[0]
+	}
+	return filepath.Join(home, ".local", "share", "goose", "sessions.db")
+}
+
+func gooseDBCandidates(home string) []string {
+	candidates := make([]string, 0, 8)
+
+	if root := strings.TrimSpace(os.Getenv("GOOSE_PATH_ROOT")); root != "" {
+		candidates = append(candidates, filepath.Join(root, "data", "sessions.db"))
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		candidates = append(candidates,
+			filepath.Join(home, "Library", "Application Support", "Block", "goose", "sessions.db"),
+			filepath.Join(home, "Library", "Application Support", "goose", "sessions.db"),
+		)
+	case "linux":
+		xdgData := os.Getenv("XDG_DATA_HOME")
+		if xdgData == "" {
+			xdgData = filepath.Join(home, ".local", "share")
+		}
+		candidates = append(candidates, filepath.Join(xdgData, "goose", "sessions.db"))
+	case "windows":
+		if appData := os.Getenv("APPDATA"); appData != "" {
+			candidates = append(candidates, filepath.Join(appData, "goose", "sessions.db"))
+		}
+		if local := os.Getenv("LOCALAPPDATA"); local != "" {
+			candidates = append(candidates, filepath.Join(local, "goose", "sessions.db"))
+		}
+	}
+
+	fallback := filepath.Join(home, ".local", "share", "goose", "sessions.db")
+	if !containsPath(candidates, fallback) {
+		candidates = append(candidates, fallback)
+	}
+
+	return candidates
+}
+
+func containsPath(paths []string, target string) bool {
+	for _, p := range paths {
+		if p == target {
+			return true
+		}
+	}
+	return false
+}
+
+func chooseInt(primary, fallback sql.NullInt64) int {
+	if primary.Valid {
+		return int(primary.Int64)
+	}
+	if fallback.Valid {
+		return int(fallback.Int64)
+	}
+	return 0
+}
+
+func parseSQLiteTime(raw string) time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}
+	}
+	layouts := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, raw); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+func resolveProjectPath(projectRoot string) string {
+	abs, err := filepath.Abs(projectRoot)
+	if err != nil {
+		return projectRoot
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = resolved
+	}
+	return filepath.Clean(abs)
+}
+
+func cwdMatchesProject(projectRoot, cwd string) bool {
+	projectAbs := resolveProjectPath(projectRoot)
+	cwdAbs := resolveProjectPath(cwd)
+
+	if cwdAbs == projectAbs {
+		return true
+	}
+	prefix := projectAbs + string(os.PathSeparator)
+	return strings.HasPrefix(cwdAbs, prefix)
+}
+
+func shortConversationID(id string) string {
+	if len(id) <= 8 {
+		return id
+	}
+	return id[:8]
+}
+
+func normalizeRole(role string) string {
+	r := strings.ToLower(strings.TrimSpace(role))
+	switch r {
+	case "assistant", "user", "system", "tool":
+		return r
+	default:
+		if r == "" {
+			return "assistant"
+		}
+		return r
+	}
+}
+
+func toSessionCategory(sessionType string) string {
+	switch strings.ToLower(strings.TrimSpace(sessionType)) {
+	case "scheduled":
+		return adapter.SessionCategoryCron
+	case "hidden", "gateway", "terminal":
+		return adapter.SessionCategorySystem
+	default:
+		return adapter.SessionCategoryInteractive
+	}
+}
+
+func parseGooseBlocks(contentJSON string) ([]GooseContentBlock, error) {
+	var blocks []GooseContentBlock
+	if err := json.Unmarshal([]byte(contentJSON), &blocks); err != nil {
+		return nil, err
+	}
+	return blocks, nil
+}
+
+func parseToolCall(call ToolResultValue) (name string, input string) {
+	if call.Status != "success" {
+		return "", ""
+	}
+	name = strings.TrimSpace(call.Value.Name)
+	if len(call.Value.Arguments) > 0 {
+		if raw, err := json.Marshal(call.Value.Arguments); err == nil {
+			input = string(raw)
+		}
+	}
+	return name, input
+}
+
+func parseToolResult(result ToolResponseValue) (output string, isErr bool) {
+	if strings.EqualFold(result.Status, "error") {
+		return strings.TrimSpace(result.Error), true
+	}
+	if !strings.EqualFold(result.Status, "success") {
+		return "", false
+	}
+
+	parts := make([]string, 0, len(result.Value.Content))
+	for _, c := range result.Value.Content {
+		text := strings.TrimSpace(c.Text)
+		if text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, "\n"), false
+}
+
+func extractModelFromMetadata(metadataJSON string) string {
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(metadataJSON), &raw); err != nil {
+		return ""
+	}
+	candidates := []string{"model", "model_name", "modelName", "provider_model", "providerModel"}
+	for _, key := range candidates {
+		if v, ok := raw[key].(string); ok && strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+type toolUseRef struct {
+	msgIdx  int
+	toolIdx int
+}
+
+type messageCacheSignature struct {
+	maxID    int64
+	count    int64
+	maxStamp int64
+}
+
+type messageCacheEntry struct {
+	sig        messageCacheSignature
+	messages   []adapter.Message
+	lastAccess time.Time
+}
+
+func (a *Adapter) messageSignature(ctx context.Context, db *sql.DB, sessionID string) (messageCacheSignature, error) {
+	var sig messageCacheSignature
+	err := db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(MAX(id), 0),
+			COUNT(*),
+			COALESCE(MAX(created_timestamp), 0)
+		FROM messages
+		WHERE session_id = ?
+	`, sessionID).Scan(&sig.maxID, &sig.count, &sig.maxStamp)
+	return sig, err
+}
+
+func copyMessages(src []adapter.Message) []adapter.Message {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]adapter.Message, len(src))
+	for i := range src {
+		out[i] = src[i]
+		if src[i].ToolUses != nil {
+			out[i].ToolUses = append([]adapter.ToolUse(nil), src[i].ToolUses...)
+		}
+		if src[i].ThinkingBlocks != nil {
+			out[i].ThinkingBlocks = append([]adapter.ThinkingBlock(nil), src[i].ThinkingBlocks...)
+		}
+		if src[i].ContentBlocks != nil {
+			out[i].ContentBlocks = append([]adapter.ContentBlock(nil), src[i].ContentBlocks...)
+		}
+	}
+	return out
+}
+
+func (a *Adapter) ensureCache() {
+	a.msgMu.Lock()
+	defer a.msgMu.Unlock()
+	if a.msgMap == nil {
+		a.msgMap = make(map[string]messageCacheEntry)
+	}
+}
+
+func (a *Adapter) evictCacheLocked() {
+	if len(a.msgMap) <= msgCacheMax {
+		return
+	}
+
+	type pair struct {
+		id string
+		at time.Time
+	}
+	items := make([]pair, 0, len(a.msgMap))
+	for id, ent := range a.msgMap {
+		items = append(items, pair{id: id, at: ent.lastAccess})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].at.Before(items[j].at)
+	})
+	excess := len(a.msgMap) - msgCacheMax
+	for i := 0; i < excess; i++ {
+		delete(a.msgMap, items[i].id)
+	}
+}
+
+func sqliteStorageSize(dbPath string) int64 {
+	var total int64
+	if info, err := os.Stat(dbPath); err == nil {
+		total += info.Size()
+	}
+	if info, err := os.Stat(dbPath + "-wal"); err == nil {
+		total += info.Size()
+	}
+	return total
+}
+
+func (a *Adapter) latestChangedSessionID() (string, error) {
+	db, err := a.getDB()
+	if err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var id string
+	// Prefer the latest written message's session, which is usually the true changed session.
+	err = db.QueryRowContext(ctx, `
+		SELECT session_id
+		FROM messages
+		ORDER BY id DESC
+		LIMIT 1
+	`).Scan(&id)
+	if err == nil {
+		return id, nil
+	}
+	if err != sql.ErrNoRows {
+		return "", err
+	}
+
+	// Fallback when there are no messages yet.
+	err = db.QueryRowContext(ctx, `
+		SELECT id
+		FROM sessions
+		ORDER BY updated_at DESC
+		LIMIT 1
+	`).Scan(&id)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return id, err
+}

--- a/internal/adapter/goose/adapter_bench_test.go
+++ b/internal/adapter/goose/adapter_bench_test.go
@@ -1,0 +1,160 @@
+package goose
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func createGooseFixtureBenchmark(b *testing.B) (dbPath, projectPath, sessionID string) {
+	b.Helper()
+
+	tmpDir := b.TempDir()
+	projectPath = filepath.Join(tmpDir, "repo")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		b.Fatalf("mkdir project: %v", err)
+	}
+	dbPath = filepath.Join(tmpDir, "sessions.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		b.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	stmts := []string{
+		`CREATE TABLE sessions (id TEXT PRIMARY KEY, name TEXT, description TEXT, session_type TEXT, working_dir TEXT, created_at TEXT, updated_at TEXT, total_tokens INTEGER, input_tokens INTEGER, output_tokens INTEGER, accumulated_total_tokens INTEGER, accumulated_input_tokens INTEGER, accumulated_output_tokens INTEGER);`,
+		`CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, message_id TEXT, session_id TEXT NOT NULL, role TEXT NOT NULL, content_json TEXT NOT NULL, created_timestamp INTEGER NOT NULL, timestamp TEXT, metadata_json TEXT);`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			b.Fatalf("create schema: %v", err)
+		}
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	sessionID = "ses_goose_bench"
+	if _, err := db.Exec(`INSERT INTO sessions(id, name, description, session_type, working_dir, created_at, updated_at, total_tokens, input_tokens, output_tokens, accumulated_total_tokens, accumulated_input_tokens, accumulated_output_tokens) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		sessionID,
+		"Bench Session",
+		"",
+		"user",
+		projectPath,
+		now.Add(-2*time.Minute).Format(time.RFC3339),
+		now.Format(time.RFC3339),
+		120,
+		80,
+		40,
+		120,
+		80,
+		40,
+	); err != nil {
+		b.Fatalf("insert session: %v", err)
+	}
+
+	userContent := `[{"type":"text","text":"Please list files"}]`
+	assistantContent := `[{"type":"text","text":"Sure"},{"type":"toolRequest","id":"tool_1","toolCall":{"status":"success","value":{"name":"list_files","arguments":{"path":"."}}}}, {"type":"toolResponse","id":"tool_1","toolResult":{"status":"success","value":{"content":[{"type":"text","text":"file1.go\nfile2.go"}]}}}]`
+	if _, err := db.Exec(`INSERT INTO messages(message_id, session_id, role, content_json, created_timestamp, timestamp, metadata_json) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+		"msg_1", sessionID, "user", userContent, now.Add(-90*time.Second).Unix(), now.Add(-90*time.Second).Format(time.RFC3339), `{"model":""}`,
+	); err != nil {
+		b.Fatalf("insert user message: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO messages(message_id, session_id, role, content_json, created_timestamp, timestamp, metadata_json) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+		"msg_2", sessionID, "assistant", assistantContent, now.Add(-60*time.Second).Unix(), now.Add(-60*time.Second).Format(time.RFC3339), `{"model":"claude-sonnet"}`,
+	); err != nil {
+		b.Fatalf("insert assistant message: %v", err)
+	}
+
+	return dbPath, projectPath, sessionID
+}
+
+func BenchmarkMessagesCacheHit(b *testing.B) {
+	dbPath, _, sessionID := createGooseFixtureBenchmark(b)
+	a := &Adapter{dbPath: dbPath}
+
+	_, _ = a.Messages(sessionID)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		msgs, err := a.Messages(sessionID)
+		if err != nil {
+			b.Fatalf("Messages: %v", err)
+		}
+		if len(msgs) == 0 {
+			b.Fatal("expected messages")
+		}
+	}
+}
+
+func BenchmarkSessionsSingleProject(b *testing.B) {
+	dbPath, projectPath, _ := createGooseFixtureBenchmark(b)
+	a := &Adapter{dbPath: dbPath}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sessions, err := a.Sessions(projectPath)
+		if err != nil {
+			b.Fatalf("Sessions: %v", err)
+		}
+		if len(sessions) == 0 {
+			b.Fatal("expected sessions")
+		}
+	}
+}
+
+func BenchmarkSessionsFiftyProject(b *testing.B) {
+	tmpDir := b.TempDir()
+	projectPath := filepath.Join(tmpDir, "repo")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		b.Fatalf("mkdir project: %v", err)
+	}
+	dbPath := filepath.Join(tmpDir, "sessions.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		b.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	stmts := []string{
+		`CREATE TABLE sessions (id TEXT PRIMARY KEY, name TEXT, description TEXT, session_type TEXT, working_dir TEXT, created_at TEXT, updated_at TEXT, total_tokens INTEGER, input_tokens INTEGER, output_tokens INTEGER, accumulated_total_tokens INTEGER, accumulated_input_tokens INTEGER, accumulated_output_tokens INTEGER);`,
+		`CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, message_id TEXT, session_id TEXT NOT NULL, role TEXT NOT NULL, content_json TEXT NOT NULL, created_timestamp INTEGER NOT NULL, timestamp TEXT, metadata_json TEXT);`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			b.Fatalf("create schema: %v", err)
+		}
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	for i := 0; i < 50; i++ {
+		sid := fmt.Sprintf("ses_goose_%03d", i)
+		updated := now.Add(-time.Duration(i) * time.Second)
+		if _, err := db.Exec(`INSERT INTO sessions(id, name, description, session_type, working_dir, created_at, updated_at, total_tokens, input_tokens, output_tokens, accumulated_total_tokens, accumulated_input_tokens, accumulated_output_tokens) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			sid, fmt.Sprintf("Session %d", i), "", "user", projectPath, updated.Add(-time.Minute).Format(time.RFC3339), updated.Format(time.RFC3339), 10, 6, 4, 10, 6, 4,
+		); err != nil {
+			b.Fatalf("insert session %d: %v", i, err)
+		}
+		if _, err := db.Exec(`INSERT INTO messages(message_id, session_id, role, content_json, created_timestamp, timestamp, metadata_json) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+			fmt.Sprintf("msg_%03d", i), sid, "user", `[{"type":"text","text":"hello"}]`, updated.Unix(), updated.Format(time.RFC3339), `{"model":"bench"}`,
+		); err != nil {
+			b.Fatalf("insert message %d: %v", i, err)
+		}
+	}
+
+	a := &Adapter{dbPath: dbPath}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sessions, err := a.Sessions(projectPath)
+		if err != nil {
+			b.Fatalf("Sessions: %v", err)
+		}
+		if len(sessions) != 50 {
+			b.Fatalf("expected 50 sessions, got %d", len(sessions))
+		}
+	}
+}

--- a/internal/adapter/goose/adapter_test.go
+++ b/internal/adapter/goose/adapter_test.go
@@ -1,0 +1,683 @@
+package goose
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/marcus/sidecar/internal/adapter"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func createGooseFixture(t *testing.T) (dbPath, projectPath, sessionID string) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	projectPath = filepath.Join(tmpDir, "repo")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	dbPath = filepath.Join(tmpDir, "sessions.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	stmts := []string{
+		`CREATE TABLE sessions (id TEXT PRIMARY KEY, name TEXT, description TEXT, session_type TEXT, working_dir TEXT, created_at TEXT, updated_at TEXT, total_tokens INTEGER, input_tokens INTEGER, output_tokens INTEGER, accumulated_total_tokens INTEGER, accumulated_input_tokens INTEGER, accumulated_output_tokens INTEGER);`,
+		`CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, message_id TEXT, session_id TEXT NOT NULL, role TEXT NOT NULL, content_json TEXT NOT NULL, created_timestamp INTEGER NOT NULL, timestamp TEXT, metadata_json TEXT);`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("create schema: %v", err)
+		}
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	sessionID = "ses_goose_001"
+	if _, err := db.Exec(`INSERT INTO sessions(id, name, description, session_type, working_dir, created_at, updated_at, total_tokens, input_tokens, output_tokens, accumulated_total_tokens, accumulated_input_tokens, accumulated_output_tokens) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		sessionID,
+		"", // force fallback to description
+		"Implement goose adapter",
+		"user",
+		projectPath,
+		now.Add(-2*time.Minute).Format("2006-01-02 15:04:05"),
+		now.Format("2006-01-02 15:04:05"),
+		120,
+		80,
+		40,
+		120,
+		80,
+		40,
+	); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+
+	userContent := `[{"type":"text","text":"Please list files"}]`
+	assistantContent := `[{"type":"text","text":"Sure"},{"type":"toolRequest","id":"tool_1","toolCall":{"status":"success","value":{"name":"list_files","arguments":{"path":"."}}}},{"type":"toolResponse","id":"tool_1","toolResult":{"status":"success","value":{"content":[{"type":"text","text":"file1.go\nfile2.go"}]}}}]`
+	if _, err := db.Exec(`INSERT INTO messages(message_id, session_id, role, content_json, created_timestamp, timestamp, metadata_json) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+		"msg_1", sessionID, "user", userContent, now.Add(-90*time.Second).Unix(), now.Add(-90*time.Second).Format(time.RFC3339), `{"model":""}`,
+	); err != nil {
+		t.Fatalf("insert user message: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO messages(message_id, session_id, role, content_json, created_timestamp, timestamp, metadata_json) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+		"msg_2", sessionID, "assistant", assistantContent, now.Add(-60*time.Second).Unix(), now.Add(-60*time.Second).Format(time.RFC3339), `{"model":"claude-sonnet"}`,
+	); err != nil {
+		t.Fatalf("insert assistant message: %v", err)
+	}
+
+	return dbPath, projectPath, sessionID
+}
+
+func TestDetectSessionsMessagesUsage(t *testing.T) {
+	dbPath, projectPath, sessionID := createGooseFixture(t)
+	a := &Adapter{dbPath: dbPath}
+
+	found, err := a.Detect(projectPath)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if !found {
+		t.Fatal("expected Detect to succeed")
+	}
+
+	sessions, err := a.Sessions(projectPath)
+	if err != nil {
+		t.Fatalf("Sessions: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	s := sessions[0]
+	if s.ID != sessionID {
+		t.Fatalf("ID = %q, want %q", s.ID, sessionID)
+	}
+	if s.Name != "Implement goose adapter" {
+		t.Fatalf("Name = %q, want fallback description", s.Name)
+	}
+	if s.AdapterID != "goose" || s.AdapterName != "Goose" {
+		t.Fatalf("adapter metadata mismatch: %q/%q", s.AdapterID, s.AdapterName)
+	}
+	if s.TotalTokens != 120 {
+		t.Fatalf("TotalTokens = %d, want 120", s.TotalTokens)
+	}
+	if s.MessageCount != 2 {
+		t.Fatalf("MessageCount = %d, want 2", s.MessageCount)
+	}
+	if s.FileSize <= 0 {
+		t.Fatalf("FileSize = %d, want >0", s.FileSize)
+	}
+
+	messages, err := a.Messages(sessionID)
+	if err != nil {
+		t.Fatalf("Messages: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(messages))
+	}
+	if messages[0].Role != "user" || messages[1].Role != "assistant" {
+		t.Fatalf("unexpected roles: %q/%q", messages[0].Role, messages[1].Role)
+	}
+	if len(messages[1].ToolUses) != 1 {
+		t.Fatalf("expected 1 tool use, got %d", len(messages[1].ToolUses))
+	}
+	if messages[1].ToolUses[0].Name != "list_files" {
+		t.Fatalf("unexpected tool name: %q", messages[1].ToolUses[0].Name)
+	}
+	if messages[1].ToolUses[0].Output == "" {
+		t.Fatal("expected linked tool output")
+	}
+	if messages[1].Model != "claude-sonnet" {
+		t.Fatalf("model = %q, want claude-sonnet", messages[1].Model)
+	}
+
+	usage, err := a.Usage(sessionID)
+	if err != nil {
+		t.Fatalf("Usage: %v", err)
+	}
+	if usage == nil {
+		t.Fatal("expected usage")
+	}
+	if usage.TotalInputTokens != 80 || usage.TotalOutputTokens != 40 {
+		t.Fatalf("usage token mismatch: in=%d out=%d", usage.TotalInputTokens, usage.TotalOutputTokens)
+	}
+
+	single, err := a.SessionByID(sessionID)
+	if err != nil {
+		t.Fatalf("SessionByID: %v", err)
+	}
+	if single.ID != sessionID {
+		t.Fatalf("SessionByID ID = %q, want %q", single.ID, sessionID)
+	}
+}
+
+func TestDetectMissingDB(t *testing.T) {
+	a := &Adapter{dbPath: filepath.Join(t.TempDir(), "missing.db")}
+	found, err := a.Detect(t.TempDir())
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if found {
+		t.Fatal("Detect should be false when DB is missing")
+	}
+}
+
+func TestWatchScopeGlobal(t *testing.T) {
+	a := New()
+	if got := a.WatchScope(); got != adapter.WatchScopeGlobal {
+		t.Fatalf("WatchScope = %v, want %v", got, adapter.WatchScopeGlobal)
+	}
+}
+
+func TestWatcherEmitsOnWALWrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "sessions.db")
+	if err := os.WriteFile(dbPath, []byte("sqlite"), 0o644); err != nil {
+		t.Fatalf("write db: %v", err)
+	}
+
+	ch, closer, err := NewWatcher(dbPath)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	defer func() { _ = closer.Close() }()
+
+	if err := os.WriteFile(dbPath+"-wal", []byte("update"), 0o644); err != nil {
+		t.Fatalf("write wal: %v", err)
+	}
+
+	select {
+	case evt := <-ch:
+		if evt.Type != adapter.EventSessionCreated && evt.Type != adapter.EventSessionUpdated {
+			t.Fatalf("unexpected event type: %v", evt.Type)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected watcher event")
+	}
+}
+
+func TestBasicAdapterMethods(t *testing.T) {
+	a := New()
+
+	if got := a.ID(); got != "goose" {
+		t.Fatalf("ID() = %q, want goose", got)
+	}
+	if got := a.Name(); got != "Goose" {
+		t.Fatalf("Name() = %q, want Goose", got)
+	}
+	if got := a.Icon(); got != "G" {
+		t.Fatalf("Icon() = %q, want G", got)
+	}
+
+	caps := a.Capabilities()
+	if !caps[adapter.CapSessions] || !caps[adapter.CapMessages] || !caps[adapter.CapUsage] || !caps[adapter.CapWatch] {
+		t.Fatalf("expected all capabilities true, got: %#v", caps)
+	}
+}
+
+func TestAdapterWatch(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "sessions.db")
+	if err := os.WriteFile(dbPath, []byte("sqlite"), 0o644); err != nil {
+		t.Fatalf("write db: %v", err)
+	}
+
+	a := &Adapter{dbPath: dbPath}
+	ch, closer, err := a.Watch(tmpDir)
+	if err != nil {
+		t.Fatalf("Watch() error: %v", err)
+	}
+	if ch == nil || closer == nil {
+		t.Fatal("Watch() returned nil channel/closer")
+	}
+	_ = closer.Close()
+}
+
+func TestAdapterWatchEnrichesSessionID(t *testing.T) {
+	dbPath, _, _ := createGooseFixture(t)
+	a := &Adapter{dbPath: dbPath}
+
+	ch, closer, err := a.Watch("")
+	if err != nil {
+		t.Fatalf("Watch() error: %v", err)
+	}
+	defer func() { _ = closer.Close() }()
+
+	if err := os.WriteFile(dbPath+"-wal", []byte("update"), 0o644); err != nil {
+		t.Fatalf("write wal: %v", err)
+	}
+
+	select {
+	case evt := <-ch:
+		if evt.Type != adapter.EventSessionCreated && evt.Type != adapter.EventSessionUpdated {
+			t.Fatalf("unexpected event type: %v", evt.Type)
+		}
+		if evt.SessionID == "" {
+			t.Fatal("expected SessionID enrichment on watch event")
+		}
+		if evt.SessionID != "ses_goose_001" {
+			t.Fatalf("expected enriched SessionID ses_goose_001, got %q", evt.SessionID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected watcher event")
+	}
+}
+
+func TestHelperFunctions(t *testing.T) {
+	t.Run("containsPath", func(t *testing.T) {
+		paths := []string{"/a", "/b"}
+		if !containsPath(paths, "/a") {
+			t.Fatal("containsPath should find existing path")
+		}
+		if containsPath(paths, "/c") {
+			t.Fatal("containsPath should not find missing path")
+		}
+	})
+
+	t.Run("chooseInt", func(t *testing.T) {
+		if got := chooseInt(sql.NullInt64{Valid: true, Int64: 3}, sql.NullInt64{Valid: true, Int64: 9}); got != 3 {
+			t.Fatalf("chooseInt(primary) = %d, want 3", got)
+		}
+		if got := chooseInt(sql.NullInt64{}, sql.NullInt64{Valid: true, Int64: 9}); got != 9 {
+			t.Fatalf("chooseInt(fallback) = %d, want 9", got)
+		}
+		if got := chooseInt(sql.NullInt64{}, sql.NullInt64{}); got != 0 {
+			t.Fatalf("chooseInt(empty) = %d, want 0", got)
+		}
+	})
+
+	t.Run("parseSQLiteTime", func(t *testing.T) {
+		if parseSQLiteTime("").IsZero() != true {
+			t.Fatal("empty time should parse to zero")
+		}
+		if parseSQLiteTime("not-a-time").IsZero() != true {
+			t.Fatal("invalid time should parse to zero")
+		}
+		if parseSQLiteTime("2026-01-02 03:04:05").IsZero() {
+			t.Fatal("valid sqlite time should parse")
+		}
+		if parseSQLiteTime(time.Now().UTC().Format(time.RFC3339Nano)).IsZero() {
+			t.Fatal("valid RFC3339 time should parse")
+		}
+	})
+
+	t.Run("role and category mapping", func(t *testing.T) {
+		if got := normalizeRole(""); got != "assistant" {
+			t.Fatalf("normalizeRole(empty) = %q", got)
+		}
+		if got := normalizeRole("USER"); got != "user" {
+			t.Fatalf("normalizeRole(USER) = %q", got)
+		}
+		if got := normalizeRole("custom"); got != "custom" {
+			t.Fatalf("normalizeRole(custom) = %q", got)
+		}
+
+		if got := toSessionCategory("scheduled"); got != adapter.SessionCategoryCron {
+			t.Fatalf("toSessionCategory(scheduled) = %q", got)
+		}
+		if got := toSessionCategory("hidden"); got != adapter.SessionCategorySystem {
+			t.Fatalf("toSessionCategory(hidden) = %q", got)
+		}
+		if got := toSessionCategory("user"); got != adapter.SessionCategoryInteractive {
+			t.Fatalf("toSessionCategory(user) = %q", got)
+		}
+	})
+
+	t.Run("shortConversationID and maxInt", func(t *testing.T) {
+		if got := shortConversationID("abcdef012345"); got != "abcdef01" {
+			t.Fatalf("shortConversationID = %q", got)
+		}
+		if got := shortConversationID("abc"); got != "abc" {
+			t.Fatalf("shortConversationID short = %q", got)
+		}
+		if got := maxInt(2, 5); got != 5 {
+			t.Fatalf("maxInt = %d, want 5", got)
+		}
+		if got := maxInt(8, 5); got != 8 {
+			t.Fatalf("maxInt = %d, want 8", got)
+		}
+	})
+}
+
+func TestGooseDBCandidatesAndFind(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("GOOSE_PATH_ROOT", tmp)
+
+	candidates := gooseDBCandidates(tmp)
+	if len(candidates) == 0 {
+		t.Fatal("gooseDBCandidates returned no paths")
+	}
+	if !strings.Contains(candidates[0], filepath.Join(tmp, "data", "sessions.db")) {
+		t.Fatalf("first candidate should respect GOOSE_PATH_ROOT, got %q", candidates[0])
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		found := false
+		for _, c := range candidates {
+			if strings.Contains(c, "Library/Application Support") && strings.Contains(c, "goose/sessions.db") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected macOS candidates in list: %#v", candidates)
+		}
+	case "linux":
+		found := false
+		for _, c := range candidates {
+			if strings.Contains(c, "goose/sessions.db") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected linux goose candidate in list: %#v", candidates)
+		}
+	}
+
+	dbPath := filepath.Join(tmp, "data", "sessions.db")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("mkdir for db path: %v", err)
+	}
+	if err := os.WriteFile(dbPath, []byte("sqlite"), 0o644); err != nil {
+		t.Fatalf("write db path: %v", err)
+	}
+	if got := findGooseDB(tmp); got != dbPath {
+		t.Fatalf("findGooseDB = %q, want %q", got, dbPath)
+	}
+}
+
+func TestInterfacesAndSearch(t *testing.T) {
+	var _ adapter.MessageSearcher = New()
+	var _ adapter.TargetedRefresher = New()
+
+	dbPath, projectPath, sessionID := createGooseFixture(t)
+	a := &Adapter{dbPath: dbPath, msgMap: make(map[string]messageCacheEntry)}
+
+	found, err := a.Detect(projectPath)
+	if err != nil || !found {
+		t.Fatalf("Detect failed: found=%v err=%v", found, err)
+	}
+
+	results, err := a.SearchMessages(sessionID, "list_files", adapter.DefaultSearchOptions())
+	if err != nil {
+		t.Fatalf("SearchMessages: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected search matches for list_files")
+	}
+}
+
+func TestParseAndPathHelpers(t *testing.T) {
+	t.Run("parseGooseBlocks error and success", func(t *testing.T) {
+		if _, err := parseGooseBlocks("{"); err == nil {
+			t.Fatal("expected parseGooseBlocks error for invalid json")
+		}
+		blocks, err := parseGooseBlocks(`[{"type":"text","text":"ok"}]`)
+		if err != nil {
+			t.Fatalf("unexpected parseGooseBlocks error: %v", err)
+		}
+		if len(blocks) != 1 || blocks[0].Text != "ok" {
+			t.Fatalf("unexpected blocks: %#v", blocks)
+		}
+	})
+
+	t.Run("parseToolCall and parseToolResult branches", func(t *testing.T) {
+		name, input := parseToolCall(ToolResultValue{Status: "error"})
+		if name != "" || input != "" {
+			t.Fatalf("expected empty tool call on error, got %q / %q", name, input)
+		}
+
+		name, input = parseToolCall(ToolResultValue{
+			Status: "success",
+			Value: ToolCallValue{
+				Name:      "run",
+				Arguments: map[string]any{"cmd": "ls"},
+			},
+		})
+		if name != "run" || !strings.Contains(input, "\"cmd\":\"ls\"") {
+			t.Fatalf("unexpected tool call parse result: %q / %q", name, input)
+		}
+
+		out, isErr := parseToolResult(ToolResponseValue{Status: "error", Error: "boom"})
+		if out != "boom" || !isErr {
+			t.Fatalf("expected error result, got out=%q isErr=%v", out, isErr)
+		}
+
+		out, isErr = parseToolResult(ToolResponseValue{Status: "unknown"})
+		if out != "" || isErr {
+			t.Fatalf("expected empty unknown status result, got out=%q isErr=%v", out, isErr)
+		}
+	})
+
+	t.Run("resolveProjectPath and cwdMatchesProject", func(t *testing.T) {
+		project := t.TempDir()
+		sub := filepath.Join(project, "subdir")
+		if err := os.MkdirAll(sub, 0o755); err != nil {
+			t.Fatalf("mkdir subdir: %v", err)
+		}
+
+		resolved := resolveProjectPath(project)
+		if !filepath.IsAbs(resolved) {
+			t.Fatalf("resolveProjectPath should return abs path, got %q", resolved)
+		}
+		if !cwdMatchesProject(project, project) {
+			t.Fatal("cwdMatchesProject should match same path")
+		}
+		if !cwdMatchesProject(project, sub) {
+			t.Fatal("cwdMatchesProject should match subdir")
+		}
+		if cwdMatchesProject(project, t.TempDir()) {
+			t.Fatal("cwdMatchesProject should not match unrelated dir")
+		}
+	})
+}
+
+func TestUsageNoRowsAndWatchError(t *testing.T) {
+	a := &Adapter{dbPath: filepath.Join(t.TempDir(), "missing.db")}
+
+	if _, _, err := a.Watch(t.TempDir()); err == nil {
+		t.Fatal("Watch should fail when db is missing")
+	}
+
+	dbPath, projectPath, _ := createGooseFixture(t)
+	a = &Adapter{dbPath: dbPath}
+
+	found, err := a.Detect(filepath.Join(projectPath, "does-not-match"))
+	if err != nil {
+		t.Fatalf("Detect mismatch path error: %v", err)
+	}
+	if found {
+		t.Fatal("Detect should be false for non-matching project")
+	}
+
+	usage, err := a.Usage("missing-session")
+	if err != nil {
+		t.Fatalf("Usage missing-session error: %v", err)
+	}
+	if usage != nil {
+		t.Fatalf("Usage missing-session should be nil, got %#v", usage)
+	}
+
+	if _, err := a.SessionByID("missing-session"); err == nil {
+		t.Fatal("SessionByID should error for missing session")
+	}
+}
+
+func TestMessagesContentVariantsAndSessionFiltering(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "repo")
+	otherPath := filepath.Join(tmpDir, "other")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	if err := os.MkdirAll(otherPath, 0o755); err != nil {
+		t.Fatalf("mkdir other: %v", err)
+	}
+
+	dbPath := filepath.Join(tmpDir, "sessions.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	stmts := []string{
+		`CREATE TABLE sessions (id TEXT PRIMARY KEY, name TEXT, description TEXT, session_type TEXT, working_dir TEXT, created_at TEXT, updated_at TEXT, total_tokens INTEGER, input_tokens INTEGER, output_tokens INTEGER, accumulated_total_tokens INTEGER, accumulated_input_tokens INTEGER, accumulated_output_tokens INTEGER);`,
+		`CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, message_id TEXT, session_id TEXT NOT NULL, role TEXT NOT NULL, content_json TEXT NOT NULL, created_timestamp INTEGER NOT NULL, timestamp TEXT, metadata_json TEXT);`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("create schema: %v", err)
+		}
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if _, err := db.Exec(`INSERT INTO sessions(id, name, description, session_type, working_dir, created_at, updated_at, total_tokens, input_tokens, output_tokens, accumulated_total_tokens, accumulated_input_tokens, accumulated_output_tokens) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"ses_main", "main", "", "scheduled", projectPath, now.Add(-3*time.Minute).Format(time.RFC3339), now.Format(time.RFC3339), nil, nil, nil, 33, 20, 13,
+	); err != nil {
+		t.Fatalf("insert ses_main: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO sessions(id, name, description, session_type, working_dir, created_at, updated_at, total_tokens, input_tokens, output_tokens, accumulated_total_tokens, accumulated_input_tokens, accumulated_output_tokens) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"ses_other", "other", "", "hidden", otherPath, now.Add(-2*time.Minute).Format(time.RFC3339), now.Add(-time.Minute).Format(time.RFC3339), 1, 1, 0, nil, nil, nil,
+	); err != nil {
+		t.Fatalf("insert ses_other: %v", err)
+	}
+
+	assistantMixed := `[
+		{"type":"thinking","thinking":"plan first"},
+		{"type":"reasoning","text":"reason note"},
+		{"type":"frontendToolRequest","id":"tool_f1","toolCall":{"status":"success","value":{"name":"open_file","arguments":{"path":"README.md"}}}},
+		{"type":"toolResponse","id":"tool_f1","toolResult":{"status":"error","error":"tool failed"}}
+	]`
+	if _, err := db.Exec(`INSERT INTO messages(message_id, session_id, role, content_json, created_timestamp, timestamp, metadata_json) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+		"m_mix", "ses_main", "assistant", assistantMixed, now.Add(-90*time.Second).Unix(), now.Add(-90*time.Second).Format(time.RFC3339), `{"modelName":"gpt-4.1"}`,
+	); err != nil {
+		t.Fatalf("insert mixed message: %v", err)
+	}
+
+	a := &Adapter{dbPath: dbPath}
+
+	sessions, err := a.Sessions(projectPath)
+	if err != nil {
+		t.Fatalf("Sessions: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 filtered session, got %d", len(sessions))
+	}
+	if sessions[0].SessionCategory != adapter.SessionCategoryCron {
+		t.Fatalf("session category = %q, want cron", sessions[0].SessionCategory)
+	}
+	if sessions[0].TotalTokens != 33 {
+		t.Fatalf("total tokens = %d, want 33", sessions[0].TotalTokens)
+	}
+
+	msgs, err := a.Messages("ses_main")
+	if err != nil {
+		t.Fatalf("Messages: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 parsed message, got %d", len(msgs))
+	}
+	m := msgs[0]
+	if len(m.ThinkingBlocks) == 0 {
+		t.Fatal("expected thinking blocks")
+	}
+	if len(m.ToolUses) != 1 || m.ToolUses[0].Name != "open_file" {
+		t.Fatalf("unexpected tool use parse: %#v", m.ToolUses)
+	}
+	if m.ToolUses[0].Output != "tool failed" {
+		t.Fatalf("expected linked tool error output, got %q", m.ToolUses[0].Output)
+	}
+	if m.Model != "gpt-4.1" {
+		t.Fatalf("model parse mismatch: %q", m.Model)
+	}
+}
+
+func TestMessagesMalformedContentReturnsError(t *testing.T) {
+	dbPath, _, sessionID := createGooseFixture(t)
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	now := time.Now().UTC().Unix()
+	if _, err := db.Exec(`INSERT INTO messages(message_id, session_id, role, content_json, created_timestamp, timestamp, metadata_json) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+		"msg_bad", sessionID, "assistant", `{`, now, time.Now().UTC().Format(time.RFC3339), `{}`,
+	); err != nil {
+		t.Fatalf("insert malformed message: %v", err)
+	}
+
+	a := &Adapter{dbPath: dbPath, msgMap: make(map[string]messageCacheEntry)}
+	if _, err := a.Messages(sessionID); err == nil {
+		t.Fatal("expected parse error for malformed content_json")
+	}
+}
+
+func TestMessagesCacheDefensiveCopy(t *testing.T) {
+	dbPath, _, sessionID := createGooseFixture(t)
+	a := &Adapter{dbPath: dbPath, msgMap: make(map[string]messageCacheEntry)}
+
+	msgs1, err := a.Messages(sessionID)
+	if err != nil {
+		t.Fatalf("Messages first: %v", err)
+	}
+	if len(msgs1) == 0 {
+		t.Fatal("expected messages")
+	}
+	orig := msgs1[0].Content
+	msgs1[0].Content = "mutated"
+
+	msgs2, err := a.Messages(sessionID)
+	if err != nil {
+		t.Fatalf("Messages second: %v", err)
+	}
+	if len(msgs2) == 0 {
+		t.Fatal("expected messages on second call")
+	}
+	if msgs2[0].Content != orig {
+		t.Fatalf("cache returned mutated content = %q, want %q", msgs2[0].Content, orig)
+	}
+}
+
+func TestMessagesCacheInvalidatesOnAppend(t *testing.T) {
+	dbPath, _, sessionID := createGooseFixture(t)
+	a := &Adapter{dbPath: dbPath, msgMap: make(map[string]messageCacheEntry)}
+
+	msgs1, err := a.Messages(sessionID)
+	if err != nil {
+		t.Fatalf("Messages first: %v", err)
+	}
+	if len(msgs1) != 2 {
+		t.Fatalf("expected 2 messages initially, got %d", len(msgs1))
+	}
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	now := time.Now().UTC()
+	if _, err := db.Exec(`INSERT INTO messages(message_id, session_id, role, content_json, created_timestamp, timestamp, metadata_json) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+		"msg_3", sessionID, "assistant", `[{"type":"text","text":"New message after cache"}]`, now.Unix(), now.Format(time.RFC3339), `{"model":"claude-sonnet"}`,
+	); err != nil {
+		t.Fatalf("insert appended message: %v", err)
+	}
+
+	msgs2, err := a.Messages(sessionID)
+	if err != nil {
+		t.Fatalf("Messages second: %v", err)
+	}
+	if len(msgs2) != 3 {
+		t.Fatalf("expected 3 messages after append, got %d", len(msgs2))
+	}
+}

--- a/internal/adapter/goose/doc.go
+++ b/internal/adapter/goose/doc.go
@@ -1,0 +1,2 @@
+// Package goose provides an adapter for Goose sessions stored in sessions.db.
+package goose

--- a/internal/adapter/goose/register.go
+++ b/internal/adapter/goose/register.go
@@ -1,0 +1,9 @@
+package goose
+
+import "github.com/marcus/sidecar/internal/adapter"
+
+func init() {
+	adapter.RegisterFactory(func() adapter.Adapter {
+		return New()
+	})
+}

--- a/internal/adapter/goose/search.go
+++ b/internal/adapter/goose/search.go
@@ -1,0 +1,17 @@
+package goose
+
+import "github.com/marcus/sidecar/internal/adapter"
+
+// SearchMessages searches message content within a session.
+// Implements adapter.MessageSearcher interface.
+func (a *Adapter) SearchMessages(sessionID, query string, opts adapter.SearchOptions) ([]adapter.MessageMatch, error) {
+	messages, err := a.Messages(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if len(messages) == 0 {
+		return nil, nil
+	}
+
+	return adapter.SearchMessagesSlice(messages, query, opts)
+}

--- a/internal/adapter/goose/search_test.go
+++ b/internal/adapter/goose/search_test.go
@@ -1,0 +1,41 @@
+package goose
+
+import (
+	"testing"
+
+	"github.com/marcus/sidecar/internal/adapter"
+)
+
+func TestSearchMessages_InterfaceCompliance(t *testing.T) {
+	a := New()
+	var _ adapter.MessageSearcher = a
+}
+
+func TestSearchMessages_NonExistentSession(t *testing.T) {
+	dbPath, _, _ := createGooseFixture(t)
+	a := &Adapter{dbPath: dbPath}
+
+	results, err := a.SearchMessages("nonexistent-session-xyz", "test", adapter.DefaultSearchOptions())
+	if err != nil {
+		t.Fatalf("expected no error for nonexistent session, got %v", err)
+	}
+	if results != nil {
+		t.Fatalf("expected nil results, got %#v", results)
+	}
+}
+
+func TestSearchMessages_FindsToolContent(t *testing.T) {
+	dbPath, _, sessionID := createGooseFixture(t)
+	a := &Adapter{dbPath: dbPath}
+
+	results, err := a.SearchMessages(sessionID, "list_files", adapter.DefaultSearchOptions())
+	if err != nil {
+		t.Fatalf("SearchMessages: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected at least one match")
+	}
+	if len(results[0].Matches) == 0 {
+		t.Fatal("expected content matches in first result")
+	}
+}

--- a/internal/adapter/goose/types.go
+++ b/internal/adapter/goose/types.go
@@ -1,0 +1,45 @@
+package goose
+
+import "encoding/json"
+
+// GooseContentBlock represents one item in Goose's messages.content_json array.
+type GooseContentBlock struct {
+	Type       string            `json:"type"`
+	Text       string            `json:"text,omitempty"`
+	Thinking   string            `json:"thinking,omitempty"`
+	ID         string            `json:"id,omitempty"`
+	ToolCall   ToolResultValue   `json:"toolCall,omitempty"`
+	ToolResult ToolResponseValue `json:"toolResult,omitempty"`
+}
+
+// ToolResultValue matches Goose's serialized tool request format.
+type ToolResultValue struct {
+	Status string        `json:"status"`
+	Value  ToolCallValue `json:"value"`
+	Error  string        `json:"error,omitempty"`
+}
+
+// ToolCallValue contains tool name + arguments for toolRequest blocks.
+type ToolCallValue struct {
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments"`
+}
+
+// ToolResponseValue matches Goose's serialized tool response format.
+type ToolResponseValue struct {
+	Status string            `json:"status"`
+	Value  ToolResponseInner `json:"value"`
+	Error  string            `json:"error,omitempty"`
+}
+
+// ToolResponseInner contains response content for toolResponse blocks.
+type ToolResponseInner struct {
+	Content []ToolResponseContent `json:"content"`
+}
+
+// ToolResponseContent captures text from rmcp Content values.
+type ToolResponseContent struct {
+	Type string          `json:"type"`
+	Text string          `json:"text"`
+	Raw  json.RawMessage `json:"-"`
+}

--- a/internal/adapter/goose/watcher.go
+++ b/internal/adapter/goose/watcher.go
@@ -1,0 +1,93 @@
+package goose
+
+import (
+	"io"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/marcus/sidecar/internal/adapter"
+)
+
+// NewWatcher watches Goose's SQLite DB and WAL files.
+func NewWatcher(dbPath string) (<-chan adapter.Event, io.Closer, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	dbDir := filepath.Dir(dbPath)
+	if err := watcher.Add(dbDir); err != nil {
+		_ = watcher.Close()
+		return nil, nil, err
+	}
+
+	walPath := dbPath + "-wal"
+	events := make(chan adapter.Event, 32)
+
+	go func() {
+		var debounceTimer *time.Timer
+		debounceDelay := 100 * time.Millisecond
+		var closed bool
+		var mu sync.Mutex
+
+		defer func() {
+			mu.Lock()
+			closed = true
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			mu.Unlock()
+			close(events)
+		}()
+
+		emit := func(eventType adapter.EventType) {
+			select {
+			case events <- adapter.Event{Type: eventType}:
+			default:
+			}
+		}
+
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+				if event.Name != dbPath && event.Name != walPath {
+					continue
+				}
+
+				mu.Lock()
+				if debounceTimer != nil {
+					debounceTimer.Stop()
+				}
+				op := event.Op
+				debounceTimer = time.AfterFunc(debounceDelay, func() {
+					mu.Lock()
+					defer mu.Unlock()
+					if closed {
+						return
+					}
+					switch {
+					case op&fsnotify.Create != 0:
+						emit(adapter.EventSessionCreated)
+					case op&fsnotify.Write != 0:
+						emit(adapter.EventSessionUpdated)
+					default:
+						emit(adapter.EventSessionUpdated)
+					}
+				})
+				mu.Unlock()
+
+			case _, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+			}
+		}
+	}()
+
+	return events, watcher, nil
+}

--- a/internal/plugins/workspace/agent_test.go
+++ b/internal/plugins/workspace/agent_test.go
@@ -143,6 +143,7 @@ func TestGetAgentCommand(t *testing.T) {
 		{AgentGemini, "gemini"},
 		{AgentCursor, "cursor-agent"},
 		{AgentOpenCode, "opencode"},
+		{AgentGoose, "goose"},
 		{AgentPi, "pi"},
 		{AgentAmp, "amp"},
 		{AgentCustom, "claude"}, // Falls back to claude
@@ -1253,43 +1254,43 @@ func TestExtractLastNLines(t *testing.T) {
 // Precedence: exact agentType key → "*" wildcard → "default" key.
 func TestResolveConfigAgentStart_WildcardFallbackChain(t *testing.T) {
 	tests := []struct {
-		name      string
+		name       string
 		agentStart map[string]string
 		agentType  AgentType
 		want       string
 	}{
 		{
-			name:      "exact match wins",
+			name:       "exact match wins",
 			agentStart: map[string]string{"claude": "my-claude", "*": "wildcard-agent", "default": "default-agent"},
 			agentType:  AgentClaude,
 			want:       "my-claude",
 		},
 		{
-			name:      "miss on exact falls through to wildcard",
+			name:       "miss on exact falls through to wildcard",
 			agentStart: map[string]string{"*": "wildcard-agent", "default": "default-agent"},
 			agentType:  AgentCodex,
 			want:       "wildcard-agent",
 		},
 		{
-			name:      "miss on exact and wildcard falls through to default",
+			name:       "miss on exact and wildcard falls through to default",
 			agentStart: map[string]string{"default": "default-agent"},
 			agentType:  AgentCodex,
 			want:       "default-agent",
 		},
 		{
-			name:      "all miss returns empty",
+			name:       "all miss returns empty",
 			agentStart: map[string]string{"gemini": "gemini-agent"},
 			agentType:  AgentCodex,
 			want:       "",
 		},
 		{
-			name:      "nil map returns empty",
+			name:       "nil map returns empty",
 			agentStart: nil,
 			agentType:  AgentClaude,
 			want:       "",
 		},
 		{
-			name:      "empty map returns empty",
+			name:       "empty map returns empty",
 			agentStart: map[string]string{},
 			agentType:  AgentClaude,
 			want:       "",

--- a/internal/plugins/workspace/types.go
+++ b/internal/plugins/workspace/types.go
@@ -23,21 +23,21 @@ var partialMouseEscapeRegex = regexp.MustCompile(`\[<\d+;\d+;\d+[Mm]?`)
 type ViewMode int
 
 const (
-	ViewModeList           ViewMode = iota // List view (default)
-	ViewModeKanban                         // Kanban board view
-	ViewModeCreate                         // New worktree modal
-	ViewModeTaskLink                       // Task link modal (for existing worktrees)
-	ViewModeMerge                          // Merge workflow modal
-	ViewModeAgentChoice                    // Agent action choice modal (attach/restart)
-	ViewModeConfirmDelete                  // Delete confirmation modal
-	ViewModeConfirmDeleteShell             // Shell delete confirmation modal
-	ViewModeCommitForMerge                 // Commit modal before merge workflow
-	ViewModePromptPicker                   // Prompt template picker modal
-	ViewModeTypeSelector                   // Type selector modal (shell vs worktree)
-	ViewModeRenameShell                    // Rename shell modal
-	ViewModeFilePicker                     // Diff file picker modal
-	ViewModeInteractive                    // Interactive mode (tmux input passthrough)
-	ViewModeFetchPR                        // Fetch remote PR modal
+	ViewModeList               ViewMode = iota // List view (default)
+	ViewModeKanban                             // Kanban board view
+	ViewModeCreate                             // New worktree modal
+	ViewModeTaskLink                           // Task link modal (for existing worktrees)
+	ViewModeMerge                              // Merge workflow modal
+	ViewModeAgentChoice                        // Agent action choice modal (attach/restart)
+	ViewModeConfirmDelete                      // Delete confirmation modal
+	ViewModeConfirmDeleteShell                 // Shell delete confirmation modal
+	ViewModeCommitForMerge                     // Commit modal before merge workflow
+	ViewModePromptPicker                       // Prompt template picker modal
+	ViewModeTypeSelector                       // Type selector modal (shell vs worktree)
+	ViewModeRenameShell                        // Rename shell modal
+	ViewModeFilePicker                         // Diff file picker modal
+	ViewModeInteractive                        // Interactive mode (tmux input passthrough)
+	ViewModeFetchPR                            // Fetch remote PR modal
 )
 
 // FocusPane represents which pane is active in the split view.
@@ -129,6 +129,7 @@ const (
 	AgentGemini   AgentType = "gemini"   // Gemini CLI
 	AgentCursor   AgentType = "cursor"   // Cursor Agent
 	AgentOpenCode AgentType = "opencode" // OpenCode
+	AgentGoose    AgentType = "goose"    // Goose CLI
 	AgentPi       AgentType = "pi"       // Pi Agent
 	AgentAmp      AgentType = "amp"      // Amp
 	AgentCustom   AgentType = "custom"   // Custom command
@@ -144,6 +145,7 @@ var SkipPermissionsFlags = map[AgentType]string{
 	AgentGemini:   "--yolo",
 	AgentCursor:   "-f",
 	AgentOpenCode: "", // No known flag
+	AgentGoose:    "", // No known flag
 	AgentPi:       "", // No known flag
 	AgentAmp:      "--dangerously-allow-all",
 }
@@ -153,8 +155,8 @@ var SkipPermissionsFlags = map[AgentType]string{
 // Only agents that support true non-interactive one-shot output are included.
 // Values are passed as arguments to exec.Command after the agent binary name.
 var PrintModeArgs = map[AgentType][]string{
-	AgentClaude: {"-p"},                // claude -p: reads prompt from stdin, prints response to stdout
-	AgentCodex:  {"exec", "-"},         // codex exec -: "-" reads prompt from stdin (convention), prints to stdout
+	AgentClaude: {"-p"},        // claude -p: reads prompt from stdin, prints response to stdout
+	AgentCodex:  {"exec", "-"}, // codex exec -: "-" reads prompt from stdin (convention), prints to stdout
 }
 
 // AgentDisplayNames provides human-readable names for agent types.
@@ -166,6 +168,7 @@ var AgentDisplayNames = map[AgentType]string{
 	AgentGemini:   "Gemini CLI",
 	AgentCursor:   "Cursor Agent",
 	AgentOpenCode: "OpenCode",
+	AgentGoose:    "Goose CLI",
 	AgentPi:       "Pi Agent",
 	AgentAmp:      "Amp",
 	AgentShell:    "Project Shell",
@@ -180,6 +183,7 @@ var shellAgentAbbreviations = map[AgentType]string{
 	AgentGemini:   "Gemini",
 	AgentCursor:   "Cursor",
 	AgentOpenCode: "OpenCode",
+	AgentGoose:    "Goose",
 	AgentPi:       "Pi",
 	AgentAmp:      "Amp",
 }
@@ -193,6 +197,7 @@ var AgentCommands = map[AgentType]string{
 	AgentGemini:   "gemini",
 	AgentCursor:   "cursor-agent",
 	AgentOpenCode: "opencode",
+	AgentGoose:    "goose",
 	AgentPi:       "pi",
 	AgentAmp:      "amp",
 }
@@ -205,6 +210,7 @@ var AgentTypeOrder = []AgentType{
 	AgentGemini,
 	AgentCursor,
 	AgentOpenCode,
+	AgentGoose,
 	AgentPi,
 	AgentAmp,
 	AgentNone,
@@ -220,6 +226,7 @@ var ShellAgentOrder = []AgentType{
 	AgentGemini,
 	AgentCursor,
 	AgentOpenCode,
+	AgentGoose,
 	AgentPi,
 	AgentAmp,
 }
@@ -258,9 +265,9 @@ type Worktree struct {
 
 // ShellSession represents a tmux shell session (not tied to a git worktree).
 type ShellSession struct {
-	Name        string    // Display name (e.g., "Shell 1")
-	TmuxName    string    // tmux session name (e.g., "sidecar-sh-project-1")
-	Agent       *Agent    // Reuses Agent struct for tmux state
+	Name        string // Display name (e.g., "Shell 1")
+	TmuxName    string // tmux session name (e.g., "sidecar-sh-project-1")
+	Agent       *Agent // Reuses Agent struct for tmux state
 	CreatedAt   time.Time
 	ChosenAgent AgentType // td-317b64: Agent type selected at creation (AgentNone for plain shell)
 	SkipPerms   bool      // td-317b64: Whether skip permissions was enabled
@@ -539,9 +546,9 @@ type validateManagedSessionsResultMsg struct {
 // Used to avoid blocking the UI thread on tmux subprocess calls (td-c2961e).
 type AsyncCaptureResultMsg struct {
 	WorkspaceName string // Worktree this capture is for
-	SessionName  string // tmux session name
-	Output       string // Captured output (empty on error)
-	Err          error  // Non-nil if capture failed
+	SessionName   string // tmux session name
+	Output        string // Captured output (empty on error)
+	Err           error  // Non-nil if capture failed
 }
 
 // AsyncShellCaptureResultMsg delivers async shell capture results.
@@ -592,4 +599,3 @@ func (c *paneIDCache) set(sessionName, paneID string) {
 		cachedAt: time.Now(),
 	}
 }
-

--- a/internal/plugins/workspace/types.go
+++ b/internal/plugins/workspace/types.go
@@ -149,6 +149,7 @@ const (
 	AgentGemini   AgentType = "gemini"   // Gemini CLI
 	AgentCursor   AgentType = "cursor"   // Cursor Agent
 	AgentOpenCode AgentType = "opencode" // OpenCode
+	AgentGoose    AgentType = "goose"    // Goose CLI
 	AgentPi       AgentType = "pi"       // Pi Agent
 	AgentAmp      AgentType = "amp"      // Amp
 	AgentCustom   AgentType = "custom"   // Custom command
@@ -164,6 +165,7 @@ var SkipPermissionsFlags = map[AgentType]string{
 	AgentGemini:   "--yolo",
 	AgentCursor:   "-f",
 	AgentOpenCode: "", // No known flag
+	AgentGoose:    "", // No known flag
 	AgentPi:       "", // No known flag
 	AgentAmp:      "--dangerously-allow-all",
 }
@@ -186,6 +188,7 @@ var AgentDisplayNames = map[AgentType]string{
 	AgentGemini:   "Gemini CLI",
 	AgentCursor:   "Cursor Agent",
 	AgentOpenCode: "OpenCode",
+	AgentGoose:    "Goose CLI",
 	AgentPi:       "Pi Agent",
 	AgentAmp:      "Amp",
 	AgentShell:    "Project Shell",
@@ -200,6 +203,7 @@ var shellAgentAbbreviations = map[AgentType]string{
 	AgentGemini:   "Gemini",
 	AgentCursor:   "Cursor",
 	AgentOpenCode: "OpenCode",
+	AgentGoose:    "Goose",
 	AgentPi:       "Pi",
 	AgentAmp:      "Amp",
 }
@@ -213,6 +217,7 @@ var AgentCommands = map[AgentType]string{
 	AgentGemini:   "gemini",
 	AgentCursor:   "cursor-agent",
 	AgentOpenCode: "opencode",
+	AgentGoose:    "goose",
 	AgentPi:       "pi",
 	AgentAmp:      "amp",
 }
@@ -225,6 +230,7 @@ var AgentTypeOrder = []AgentType{
 	AgentGemini,
 	AgentCursor,
 	AgentOpenCode,
+	AgentGoose,
 	AgentPi,
 	AgentAmp,
 	AgentNone,
@@ -240,6 +246,7 @@ var ShellAgentOrder = []AgentType{
 	AgentGemini,
 	AgentCursor,
 	AgentOpenCode,
+	AgentGoose,
 	AgentPi,
 	AgentAmp,
 }


### PR DESCRIPTION
Add Goose support across conversations and workspace flows.

Adapter implementation (internal/adapter/goose):
- Implement full adapter contract: Detect, Sessions, SessionByID, Messages, Usage, Watch
- Register adapter via register.go and wire startup import in cmd/sidecar/main.go
- Parse Goose SQLite schema (sessions.db / messages.content_json) into Sidecar message model
- Map structured content blocks (text, thinking/reasoning, toolRequest/toolResponse)
- Link tool_result blocks back to tool_use entries by ToolUseID parity
- Add MessageSearcher support via SearchMessages() using shared adapter search utilities
- Add TargetedRefresher support via SessionByID() for O(1) targeted refresh
- Add bounded message cache (LRU-style eviction, max 128) with signature-based invalidation
- Return defensive message copies from cache to prevent mutation leaks
- Strictly fail on malformed message content_json parse errors
- Populate Session.FileSize for DB-backed sessions using sessions.db + sessions.db-wal size
- Optimize Sessions query to use LEFT JOIN + GROUP BY counts instead of correlated per-row subquery
- Implement WAL-aware watcher with debounce + non-blocking sends and best-effort SessionID enrichment

Workspace integration (internal/plugins/workspace):
- Add new AgentType constant: goose
- Add Goose display names/abbreviations, command mapping, and ordering in create/shell selectors
- Keep skip-permissions unset for Goose (no known flag)
- Extend agent command test coverage for Goose mapping

Tests and benchmarks:
- Add comprehensive adapter unit tests (detect/sessions/messages/usage/watch/search/session lookup)
- Add cache safety tests (defensive copy + invalidation on append)
- Add malformed-content error-path test
- Add benchmark suite for cache-hit messages and session listing (including 50-session benchmark)

Validation run:
- go test ./internal/adapter/goose -run .
- go test ./internal/adapter/goose -bench . -benchmem -run '^$'
- go test ./internal/plugins/workspace -run '^TestGetAgentCommand$'
- go build ./...