### PR TITLE
fix: stop modifying .gitignore after XDG state migration

### DIFF
--- a/internal/plugins/gitstatus/no_repo.go
+++ b/internal/plugins/gitstatus/no_repo.go
@@ -2,30 +2,13 @@ package gitstatus
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/marcus/sidecar/internal/plugin"
 	"github.com/marcus/sidecar/internal/styles"
 )
-
-// sidecarGitignoreEntries lists all sidecar state paths that should be ignored
-// by git. These are added both when initializing a new repository and when
-// sidecar first opens an existing repository, ensuring worktree operations
-// never produce unexpected git noise.
-var sidecarGitignoreEntries = []string{
-	".todos/",
-	".sidecar/",
-	".sidecar-agent",
-	".sidecar-task",
-	".sidecar-pr",
-	".sidecar-start.sh",
-	".sidecar-base",
-	".td-root",
-}
 
 // RepoDetectedMsg is sent after probing for a repository in the current workdir.
 type RepoDetectedMsg struct {
@@ -37,8 +20,7 @@ type RepoDetectedMsg struct {
 func (m RepoDetectedMsg) GetEpoch() uint64 { return m.Epoch }
 
 // RepoInitDoneMsg is sent after attempting to run git init.
-// Root is set on successful repository creation. Err is optional and may contain
-// non-fatal warnings (for example, .gitignore update failures).
+// Root is set on successful repository creation. Err is set on failure.
 type RepoInitDoneMsg struct {
 	Epoch uint64
 	Root  string
@@ -80,8 +62,7 @@ func (p *Plugin) detectRepo() tea.Cmd {
 	}
 }
 
-// initRepo initializes a git repository at the current workdir and ensures
-// sidecar local-state paths are ignored.
+// initRepo initializes a git repository at the current workdir.
 func (p *Plugin) initRepo() tea.Cmd {
 	if p.ctx == nil {
 		return nil
@@ -103,10 +84,6 @@ func (p *Plugin) initRepo() tea.Cmd {
 		root, err := resolveGitRoot(workDir)
 		if err != nil {
 			return RepoInitDoneMsg{Epoch: epoch, Err: fmt.Errorf("git init succeeded but repository was not detected: %w", err)}
-		}
-
-		if err := ensureGitignoreEntries(workDir, sidecarGitignoreEntries); err != nil {
-			return RepoInitDoneMsg{Epoch: epoch, Root: root, Err: err}
 		}
 
 		return RepoInitDoneMsg{Epoch: epoch, Root: root}
@@ -143,53 +120,3 @@ func (p *Plugin) renderNoRepoView() string {
 	return styles.RenderPanel(sb.String(), p.width, panelHeight, true)
 }
 
-// ensureGitignoreEntries appends missing entries to .gitignore in workDir.
-func ensureGitignoreEntries(workDir string, entries []string) error {
-	gitignorePath := filepath.Join(workDir, ".gitignore")
-
-	var existing string
-	if data, err := os.ReadFile(gitignorePath); err == nil {
-		existing = string(data)
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("read .gitignore: %w", err)
-	}
-
-	var missing []string
-	for _, entry := range entries {
-		found := false
-		for _, line := range strings.Split(existing, "\n") {
-			if strings.TrimSpace(line) == entry {
-				found = true
-				break
-			}
-		}
-		if !found {
-			missing = append(missing, entry)
-		}
-	}
-	if len(missing) == 0 {
-		return nil
-	}
-
-	var toAppend strings.Builder
-	if existing != "" && !strings.HasSuffix(existing, "\n") {
-		toAppend.WriteString("\n")
-	}
-	for _, entry := range missing {
-		toAppend.WriteString(entry)
-		toAppend.WriteString("\n")
-	}
-
-	f, err := os.OpenFile(gitignorePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return fmt.Errorf("open .gitignore: %w", err)
-	}
-	defer func() {
-		_ = f.Close()
-	}()
-
-	if _, err := f.WriteString(toAppend.String()); err != nil {
-		return fmt.Errorf("write .gitignore: %w", err)
-	}
-	return nil
-}

--- a/internal/plugins/gitstatus/no_repo_test.go
+++ b/internal/plugins/gitstatus/no_repo_test.go
@@ -1,9 +1,7 @@
 package gitstatus
 
 import (
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -61,109 +59,6 @@ func TestInit_SwitchRepoToNoRepoClearsRepoState(t *testing.T) {
 	}
 	if p.repoRoot != "" {
 		t.Fatalf("repoRoot = %q, want empty", p.repoRoot)
-	}
-}
-
-func TestEnsureGitignoreEntries_AddAndIdempotent(t *testing.T) {
-	tmp := t.TempDir()
-	gitignore := filepath.Join(tmp, ".gitignore")
-
-	if err := os.WriteFile(gitignore, []byte("node_modules/\n"), 0644); err != nil {
-		t.Fatalf("write .gitignore: %v", err)
-	}
-
-	if err := ensureGitignoreEntries(tmp, sidecarGitignoreEntries); err != nil {
-		t.Fatalf("ensureGitignoreEntries() first call error = %v", err)
-	}
-	if err := ensureGitignoreEntries(tmp, sidecarGitignoreEntries); err != nil {
-		t.Fatalf("ensureGitignoreEntries() second call error = %v", err)
-	}
-
-	data, err := os.ReadFile(gitignore)
-	if err != nil {
-		t.Fatalf("read .gitignore: %v", err)
-	}
-	content := string(data)
-	for _, entry := range sidecarGitignoreEntries {
-		if strings.Count(content, entry) != 1 {
-			t.Fatalf("%q count = %d, want 1\ncontent:\n%s", entry, strings.Count(content, entry), content)
-		}
-	}
-}
-
-func TestEnsureGitignoreEntries_AllSidecarEntries(t *testing.T) {
-	tmp := t.TempDir()
-
-	// Verify all expected sidecar state paths are covered
-	expected := []string{
-		".todos/",
-		".sidecar/",
-		".sidecar-agent",
-		".sidecar-task",
-		".sidecar-pr",
-		".sidecar-start.sh",
-		".sidecar-base",
-		".td-root",
-	}
-	for _, e := range expected {
-		found := false
-		for _, s := range sidecarGitignoreEntries {
-			if s == e {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("sidecarGitignoreEntries missing expected entry %q", e)
-		}
-	}
-
-	// Ensure entries are applied cleanly to an empty .gitignore
-	if err := ensureGitignoreEntries(tmp, sidecarGitignoreEntries); err != nil {
-		t.Fatalf("ensureGitignoreEntries() error = %v", err)
-	}
-	data, err := os.ReadFile(filepath.Join(tmp, ".gitignore"))
-	if err != nil {
-		t.Fatalf("read .gitignore: %v", err)
-	}
-	content := string(data)
-	for _, entry := range expected {
-		if !strings.Contains(content, entry) {
-			t.Errorf(".gitignore missing entry %q\ncontent:\n%s", entry, content)
-		}
-	}
-}
-
-func TestStart_EnsuresGitignoreForExistingRepo(t *testing.T) {
-	repoDir := t.TempDir()
-	initCmd := exec.Command("git", "init")
-	initCmd.Dir = repoDir
-	if out, err := initCmd.CombinedOutput(); err != nil {
-		t.Fatalf("git init failed: %v (%s)", err, strings.TrimSpace(string(out)))
-	}
-
-	// Write a .gitignore that deliberately omits sidecar entries
-	gitignore := filepath.Join(repoDir, ".gitignore")
-	if err := os.WriteFile(gitignore, []byte("node_modules/\n"), 0644); err != nil {
-		t.Fatalf("write .gitignore: %v", err)
-	}
-
-	p := New()
-	if err := p.Init(&plugin.Context{WorkDir: repoDir}); err != nil {
-		t.Fatalf("Init() error = %v", err)
-	}
-	// Call Start() synchronously — we only care about the side-effect (gitignore update)
-	_ = p.Start()
-
-	data, err := os.ReadFile(gitignore)
-	if err != nil {
-		t.Fatalf("read .gitignore: %v", err)
-	}
-	content := string(data)
-	for _, entry := range sidecarGitignoreEntries {
-		if !strings.Contains(content, entry) {
-			t.Errorf("after Start(), .gitignore missing entry %q\ncontent:\n%s", entry, content)
-		}
 	}
 }
 

--- a/internal/plugins/gitstatus/plugin.go
+++ b/internal/plugins/gitstatus/plugin.go
@@ -310,10 +310,6 @@ func (p *Plugin) Start() tea.Cmd {
 	if !p.hasRepo {
 		return nil
 	}
-	// Ensure all sidecar state paths are in .gitignore on every startup.
-	// This is intentionally best-effort: failures are non-fatal since the
-	// project already has a repo and the user can still work.
-	_ = ensureGitignoreEntries(p.repoRoot, sidecarGitignoreEntries)
 	return tea.Batch(
 		p.refresh(),
 		p.startWatcher(),

--- a/internal/plugins/workspace/setup.go
+++ b/internal/plugins/workspace/setup.go
@@ -12,19 +12,6 @@ const (
 	setupScriptName = ".worktree-setup.sh"
 )
 
-// Sidecar files that should be in .gitignore
-var sidecarGitignoreEntries = []string{
-	".sidecar/",
-	".sidecar-agent",
-	".sidecar-agent-start",
-	".sidecar-task",
-	".sidecar-pr",
-	".sidecar-start.sh",
-	".sidecar-base",
-	".td-root",
-}
-
-
 var (
 	// Default env files to copy
 	defaultEnvFiles = []string{".env", ".env.local", ".env.development", ".env.development.local"}


### PR DESCRIPTION
## Summary
- Remove `ensureGitignoreEntries` and `sidecarGitignoreEntries` from the gitstatus plugin — since state files moved to `~/.local/state/sidecar/`, these entries (`.sidecar/`, `.sidecar-agent`, `.sidecar-task`, etc.) are no longer created in the project root
- Remove the startup hook in `plugin.go:Start()` that appended to `.gitignore` on every launch
- Remove the duplicate unused `sidecarGitignoreEntries` list from `workspace/setup.go`
- Remove now-obsolete gitignore tests

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/plugins/gitstatus/...` passes
- [x] Verify sidecar no longer modifies `.gitignore` when opening a project

🤖 Generated with [Claude Code](https://claude.com/claude-code)