### PR TITLE
feat: configurable sidebar display (hide repo prefix, agent, task, stats)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,6 +87,21 @@ type WorkspacePluginConfig struct {
 	InteractiveCopyKey string `json:"interactiveCopyKey,omitempty"`
 	// InteractivePasteKey is the keybinding to paste clipboard in interactive mode. Default: "alt+v".
 	InteractivePasteKey string `json:"interactivePasteKey,omitempty"`
+	// SidebarDisplay controls what information is shown in the workspace sidebar entries.
+	SidebarDisplay SidebarDisplayConfig `json:"sidebarDisplay"`
+}
+
+// SidebarDisplayConfig controls visibility of workspace sidebar entry elements.
+type SidebarDisplayConfig struct {
+	// HideRepoPrefix strips the repo name prefix from worktree names (e.g., "myrepo-feature" → "feature").
+	// Default: false (show full name).
+	HideRepoPrefix bool `json:"hideRepoPrefix"`
+	// HideAgent hides the agent type label (e.g., "claude") on the second line. Default: false.
+	HideAgent bool `json:"hideAgent"`
+	// HideTask hides the linked task ID (e.g., "td-abc123") on the second line. Default: false.
+	HideTask bool `json:"hideTask"`
+	// HideStats hides the +/- line change stats on the second line. Default: false.
+	HideStats bool `json:"hideStats"`
 }
 
 // NotesPluginConfig configures the notes plugin.

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -79,15 +79,23 @@ type rawPluginsConfig struct {
 }
 
 type rawWorkspaceConfig struct {
-	DirPrefix            *bool           `json:"dirPrefix"`
-	DefaultAgentType     string          `json:"defaultAgentType"`
-	LegacyDefaultAgent   string          `json:"defaultAgent"` // Backward compatibility
-	AgentStart           json.RawMessage `json:"agentStart"`
-	TmuxCaptureMaxBytes  *int            `json:"tmuxCaptureMaxBytes"`
-	InteractiveExitKey   string          `json:"interactiveExitKey"`
-	InteractiveAttachKey string          `json:"interactiveAttachKey"`
-	InteractiveCopyKey   string          `json:"interactiveCopyKey"`
-	InteractivePasteKey  string          `json:"interactivePasteKey"`
+	DirPrefix            *bool                    `json:"dirPrefix"`
+	DefaultAgentType     string                   `json:"defaultAgentType"`
+	LegacyDefaultAgent   string                   `json:"defaultAgent"` // Backward compatibility
+	AgentStart           json.RawMessage           `json:"agentStart"`
+	TmuxCaptureMaxBytes  *int                     `json:"tmuxCaptureMaxBytes"`
+	InteractiveExitKey   string                   `json:"interactiveExitKey"`
+	InteractiveAttachKey string                   `json:"interactiveAttachKey"`
+	InteractiveCopyKey   string                   `json:"interactiveCopyKey"`
+	InteractivePasteKey  string                   `json:"interactivePasteKey"`
+	SidebarDisplay       *rawSidebarDisplayConfig `json:"sidebarDisplay"`
+}
+
+type rawSidebarDisplayConfig struct {
+	HideRepoPrefix *bool `json:"hideRepoPrefix"`
+	HideAgent      *bool `json:"hideAgent"`
+	HideTask       *bool `json:"hideTask"`
+	HideStats      *bool `json:"hideStats"`
 }
 
 type rawGitStatusConfig struct {
@@ -244,6 +252,20 @@ func mergeConfig(cfg *Config, raw *rawConfig) {
 	}
 	if raw.Plugins.Workspace.InteractivePasteKey != "" {
 		cfg.Plugins.Workspace.InteractivePasteKey = raw.Plugins.Workspace.InteractivePasteKey
+	}
+	if sd := raw.Plugins.Workspace.SidebarDisplay; sd != nil {
+		if sd.HideRepoPrefix != nil {
+			cfg.Plugins.Workspace.SidebarDisplay.HideRepoPrefix = *sd.HideRepoPrefix
+		}
+		if sd.HideAgent != nil {
+			cfg.Plugins.Workspace.SidebarDisplay.HideAgent = *sd.HideAgent
+		}
+		if sd.HideTask != nil {
+			cfg.Plugins.Workspace.SidebarDisplay.HideTask = *sd.HideTask
+		}
+		if sd.HideStats != nil {
+			cfg.Plugins.Workspace.SidebarDisplay.HideStats = *sd.HideStats
+		}
 	}
 
 	// Keymap

--- a/internal/config/saver.go
+++ b/internal/config/saver.go
@@ -47,14 +47,15 @@ type saveConversationsConfig struct {
 }
 
 type saveWorkspaceConfig struct {
-	DirPrefix            *bool             `json:"dirPrefix,omitempty"`
-	DefaultAgentType     string            `json:"defaultAgentType,omitempty"`
-	AgentStart           map[string]string `json:"agentStart,omitempty"`
-	TmuxCaptureMaxBytes  *int              `json:"tmuxCaptureMaxBytes,omitempty"`
-	InteractiveExitKey   string            `json:"interactiveExitKey,omitempty"`
-	InteractiveAttachKey string            `json:"interactiveAttachKey,omitempty"`
-	InteractiveCopyKey   string            `json:"interactiveCopyKey,omitempty"`
-	InteractivePasteKey  string            `json:"interactivePasteKey,omitempty"`
+	DirPrefix            *bool                `json:"dirPrefix,omitempty"`
+	DefaultAgentType     string               `json:"defaultAgentType,omitempty"`
+	AgentStart           map[string]string    `json:"agentStart,omitempty"`
+	TmuxCaptureMaxBytes  *int                 `json:"tmuxCaptureMaxBytes,omitempty"`
+	InteractiveExitKey   string               `json:"interactiveExitKey,omitempty"`
+	InteractiveAttachKey string               `json:"interactiveAttachKey,omitempty"`
+	InteractiveCopyKey   string               `json:"interactiveCopyKey,omitempty"`
+	InteractivePasteKey  string               `json:"interactivePasteKey,omitempty"`
+	SidebarDisplay       *SidebarDisplayConfig `json:"sidebarDisplay,omitempty"`
 }
 
 // toSaveConfig converts Config to the JSON-serializable format.
@@ -88,6 +89,7 @@ func toSaveConfig(cfg *Config) saveConfig {
 				InteractiveAttachKey: cfg.Plugins.Workspace.InteractiveAttachKey,
 				InteractiveCopyKey:   cfg.Plugins.Workspace.InteractiveCopyKey,
 				InteractivePasteKey:  cfg.Plugins.Workspace.InteractivePasteKey,
+				SidebarDisplay:       &cfg.Plugins.Workspace.SidebarDisplay,
 			},
 		},
 		Keymap:   cfg.Keymap,

--- a/internal/plugins/workspace/view_list.go
+++ b/internal/plugins/workspace/view_list.go
@@ -2,11 +2,13 @@ package workspace
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/marcus/sidecar/internal/config"
 	"github.com/marcus/sidecar/internal/styles"
 	"github.com/marcus/sidecar/internal/ui"
 )
@@ -445,6 +447,13 @@ func (p *Plugin) renderWorktreeItem(wt *Worktree, selected bool, width int) stri
 
 	// Name and time
 	name := wt.Name
+	// Strip repo prefix from non-main worktrees when configured
+	if !wt.IsMain && p.ctx.Config != nil && p.ctx.Config.Plugins.Workspace.SidebarDisplay.HideRepoPrefix {
+		repoName := filepath.Base(p.ctx.ProjectRoot)
+		if repoName != "" && strings.HasPrefix(name, repoName+"-") {
+			name = name[len(repoName)+1:]
+		}
+	}
 	timeStr := formatRelativeTime(wt.UpdatedAt)
 
 	// Calculate max name width to prevent wrapping
@@ -479,9 +488,15 @@ func (p *Plugin) renderWorktreeItem(wt *Worktree, selected bool, width int) stri
 		}
 	}
 
+	// Sidebar display settings
+	var sdCfg config.SidebarDisplayConfig
+	if p.ctx.Config != nil {
+		sdCfg = p.ctx.Config.Plugins.Workspace.SidebarDisplay
+	}
+
 	// Stats if available
 	statsStr := ""
-	if wt.Stats != nil && (wt.Stats.Additions > 0 || wt.Stats.Deletions > 0) {
+	if !sdCfg.HideStats && wt.Stats != nil && (wt.Stats.Additions > 0 || wt.Stats.Deletions > 0) {
 		statsStr = fmt.Sprintf("+%d -%d", wt.Stats.Additions, wt.Stats.Deletions)
 	}
 
@@ -490,14 +505,16 @@ func (p *Plugin) renderWorktreeItem(wt *Worktree, selected bool, width int) stri
 	if wt.IsMain {
 		// For root workspace, show branch name instead of agent
 		parts = append(parts, wt.Branch)
-	} else if wt.Agent != nil {
-		parts = append(parts, string(wt.Agent.Type))
-	} else if wt.ChosenAgentType != "" && wt.ChosenAgentType != AgentNone {
-		parts = append(parts, string(wt.ChosenAgentType))
-	} else {
-		parts = append(parts, "—")
+	} else if !sdCfg.HideAgent {
+		if wt.Agent != nil {
+			parts = append(parts, string(wt.Agent.Type))
+		} else if wt.ChosenAgentType != "" && wt.ChosenAgentType != AgentNone {
+			parts = append(parts, string(wt.ChosenAgentType))
+		} else {
+			parts = append(parts, "—")
+		}
 	}
-	if wt.TaskID != "" {
+	if !sdCfg.HideTask && wt.TaskID != "" {
 		parts = append(parts, wt.TaskID)
 	}
 	if statsStr != "" {
@@ -596,14 +613,16 @@ func (p *Plugin) renderWorktreeItem(wt *Worktree, selected bool, width int) stri
 	if wt.IsMain {
 		// For root workspace, show branch name instead of agent
 		styledParts = append(styledParts, wt.Branch)
-	} else if wt.Agent != nil {
-		styledParts = append(styledParts, string(wt.Agent.Type))
-	} else if wt.ChosenAgentType != "" && wt.ChosenAgentType != AgentNone {
-		styledParts = append(styledParts, dimText(string(wt.ChosenAgentType)))
-	} else {
-		styledParts = append(styledParts, "—")
+	} else if !sdCfg.HideAgent {
+		if wt.Agent != nil {
+			styledParts = append(styledParts, string(wt.Agent.Type))
+		} else if wt.ChosenAgentType != "" && wt.ChosenAgentType != AgentNone {
+			styledParts = append(styledParts, dimText(string(wt.ChosenAgentType)))
+		} else {
+			styledParts = append(styledParts, "—")
+		}
 	}
-	if wt.TaskID != "" {
+	if !sdCfg.HideTask && wt.TaskID != "" {
 		styledParts = append(styledParts, wt.TaskID)
 	}
 	if statsStr != "" {


### PR DESCRIPTION
## Summary
- Add `sidebarDisplay` config under `plugins.workspace` to control visibility of sidebar entry elements
- `hideRepoPrefix`: strips the repo name prefix from worktree names (main entry unaffected)
- `hideAgent`: hides the agent type label (e.g., "claude") on the second line
- `hideTask`: hides the linked task ID on the second line
- `hideStats`: hides the +/- line change stats on the second line

## Example config
```json
"plugins": {
  "workspace": {
    "sidebarDisplay": {
      "hideRepoPrefix": true,
      "hideAgent": true,
      "hideTask": true
    }
  }
}
```

Goes well with #236 (lower sidebar minimum width) for a more compact sidebar.

## Test plan
- [ ] Set `hideRepoPrefix: true` — verify worktree names drop the repo prefix, main entry keeps full name
- [ ] Set `hideAgent: true` — verify agent label disappears from second line
- [ ] Set `hideTask: true` — verify task ID disappears from second line
- [ ] Set `hideStats: true` — verify +/- stats disappear from second line
- [ ] Verify defaults (all false) show everything as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)