### PR TITLE
fix: lower workspace sidebar minimum width from 25 to 15 columns

### DIFF
--- a/internal/plugins/workspace/interactive.go
+++ b/internal/plugins/workspace/interactive.go
@@ -519,8 +519,8 @@ func (p *Plugin) calculatePreviewDimensions() (width, height int) {
 		// Account for sidebar and divider (same calculation as renderListView)
 		available := p.width - dividerWidth
 		sidebarW := (available * p.sidebarWidth) / 100
-		if sidebarW < 25 {
-			sidebarW = 25
+		if sidebarW < 15 {
+			sidebarW = 15
 		}
 		if sidebarW > available-40 {
 			sidebarW = available - 40
@@ -1121,8 +1121,8 @@ func (p *Plugin) interactiveMouseCoords(x, y int) (col, row int, ok bool) {
 	if p.sidebarVisible {
 		available := p.width - dividerWidth
 		sidebarW := (available * p.sidebarWidth) / 100
-		if sidebarW < 25 {
-			sidebarW = 25
+		if sidebarW < 15 {
+			sidebarW = 15
 		}
 		if sidebarW > available-40 {
 			sidebarW = available - 40

--- a/internal/plugins/workspace/interactive_test.go
+++ b/internal/plugins/workspace/interactive_test.go
@@ -1187,8 +1187,8 @@ func TestCalculatePreviewDimensions_WidthConsistency(t *testing.T) {
 				// Sidebar visible: same calculation as in renderListView
 				available := tt.totalWidth - dividerWidth
 				sidebarW := (available * p.sidebarWidth) / 100
-				if sidebarW < 25 {
-					sidebarW = 25
+				if sidebarW < 15 {
+					sidebarW = 15
 				}
 				if sidebarW > available-40 {
 					sidebarW = available - 40

--- a/internal/plugins/workspace/mouse.go
+++ b/internal/plugins/workspace/mouse.go
@@ -936,9 +936,9 @@ func (p *Plugin) handleMouseDrag(action mouse.MouseAction) tea.Cmd {
 		startValue := p.mouseHandler.DragStartValue()
 		newWidth := startValue + (action.DragDX * 100 / p.width) // Convert px delta to %
 
-		// Clamp to reasonable bounds (20% - 60%)
-		if newWidth < 20 {
-			newWidth = 20
+		// Clamp to reasonable bounds (10% - 60%)
+		if newWidth < 10 {
+			newWidth = 10
 		}
 		if newWidth > 60 {
 			newWidth = 60

--- a/internal/plugins/workspace/view_list.go
+++ b/internal/plugins/workspace/view_list.go
@@ -137,8 +137,8 @@ func (p *Plugin) renderListView(width, height int) string {
 	// RenderPanel handles borders internally, so only subtract divider from available space
 	available := width - dividerWidth
 	sidebarW := (available * p.sidebarWidth) / 100
-	if sidebarW < 25 {
-		sidebarW = 25
+	if sidebarW < 15 {
+		sidebarW = 15
 	}
 	if sidebarW > available-40 {
 		sidebarW = available - 40


### PR DESCRIPTION
## Summary
- Reduce the sidebar render-time floor from 25 to 15 columns
- Reduce the drag clamp from 20% to 10% so the sidebar can be shrunk further
- Allows more screen space for the preview pane on smaller terminals

Goes well with #235 (configurable sidebar display) for a more compact sidebar.

## Test plan
- [ ] Drag sidebar divider to the left — verify it shrinks below the previous minimum
- [ ] Verify sidebar content renders correctly at narrow widths (15-20 columns)
- [ ] Verify preview pane gets the extra space
- [ ] Verify interactive mode dimensions calculate correctly at narrow sidebar widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)