### PR TITLE
feat: keyboard pane resizing and vim-style navigation

### DIFF
--- a/.claude/skills/keyboard-shortcuts/SKILL.md
+++ b/.claude/skills/keyboard-shortcuts/SKILL.md
@@ -66,6 +66,8 @@ TD shortcuts are dynamically exported from TD itself via `ExportBindings()` and 
 | `\` | Toggle sidebar visibility |
 | `h` / `left` | Focus left pane |
 | `l` / `right` | Focus right pane |
+| `+` | Grow sidebar width |
+| `-` | Shrink sidebar width |
 
 ## Git Status Plugin
 

--- a/internal/keymap/bindings.go
+++ b/internal/keymap/bindings.go
@@ -51,6 +51,8 @@ func DefaultBindings() []Binding {
 		{Key: "k", Command: "cursor-up", Context: "git-status"},
 		{Key: "tab", Command: "switch-pane", Context: "git-status"},
 		{Key: "shift+tab", Command: "switch-pane", Context: "git-status"},
+		{Key: "l", Command: "focus-right", Context: "git-status"},
+		{Key: "right", Command: "focus-right", Context: "git-status"},
 		{Key: "s", Command: "stage-file", Context: "git-status"},
 		{Key: "u", Command: "unstage-file", Context: "git-status"},
 		{Key: "S", Command: "stage-all", Context: "git-status"},
@@ -74,6 +76,8 @@ func DefaultBindings() []Binding {
 		{Key: "Y", Command: "yank-path", Context: "git-status"},
 		{Key: "D", Command: "discard-changes", Context: "git-status"},
 		{Key: "\\", Command: "toggle-sidebar", Context: "git-status"},
+		{Key: "+", Command: "resize-pane-grow", Context: "git-status"},
+		{Key: "-", Command: "resize-pane-shrink", Context: "git-status"},
 
 		// Git status commits context (sidebar)
 		{Key: "j", Command: "cursor-down", Context: "git-status-commits"},
@@ -94,6 +98,8 @@ func DefaultBindings() []Binding {
 		{Key: "P", Command: "push", Context: "git-status-commits"},
 		{Key: "L", Command: "pull", Context: "git-status-commits"},
 		{Key: "\\", Command: "toggle-sidebar", Context: "git-status-commits"},
+		{Key: "+", Command: "resize-pane-grow", Context: "git-status-commits"},
+		{Key: "-", Command: "resize-pane-shrink", Context: "git-status-commits"},
 
 		// Git history search modal context
 		{Key: "enter", Command: "select", Context: "git-history-search"},
@@ -120,6 +126,8 @@ func DefaultBindings() []Binding {
 		{Key: "v", Command: "toggle-diff-view", Context: "git-status-diff"},
 		{Key: "\\", Command: "toggle-sidebar", Context: "git-status-diff"},
 		{Key: "w", Command: "toggle-wrap", Context: "git-status-diff"},
+		{Key: "+", Command: "resize-pane-grow", Context: "git-status-diff"},
+		{Key: "-", Command: "resize-pane-shrink", Context: "git-status-diff"},
 
 		// Git commit preview context
 		{Key: "j", Command: "scroll-down", Context: "git-commit-preview"},
@@ -131,6 +139,8 @@ func DefaultBindings() []Binding {
 		{Key: "o", Command: "open-in-github", Context: "git-commit-preview"},
 		{Key: "b", Command: "open-in-file-browser", Context: "git-commit-preview"},
 		{Key: "\\", Command: "toggle-sidebar", Context: "git-commit-preview"},
+		{Key: "+", Command: "resize-pane-grow", Context: "git-commit-preview"},
+		{Key: "-", Command: "resize-pane-shrink", Context: "git-commit-preview"},
 
 		// Git diff context (full screen)
 		{Key: "esc", Command: "close-diff", Context: "git-diff"},
@@ -222,6 +232,8 @@ func DefaultBindings() []Binding {
 		{Key: "Y", Command: "yank-resume", Context: "conversations-sidebar"},
 		{Key: "C", Command: "toggle-category", Context: "conversations-sidebar"},
 		{Key: "R", Command: "resume-in-workspace", Context: "conversations-sidebar"},
+		{Key: "+", Command: "resize-pane-grow", Context: "conversations-sidebar"},
+		{Key: "-", Command: "resize-pane-shrink", Context: "conversations-sidebar"},
 
 		// Conversations main context (two-pane mode, right pane focused)
 		{Key: "tab", Command: "switch-pane", Context: "conversations-main"},
@@ -240,10 +252,14 @@ func DefaultBindings() []Binding {
 		{Key: "y", Command: "yank-details", Context: "conversations-main"},
 		{Key: "Y", Command: "yank-resume", Context: "conversations-main"},
 		{Key: "R", Command: "resume-in-workspace", Context: "conversations-main"},
+		{Key: "+", Command: "resize-pane-grow", Context: "conversations-main"},
+		{Key: "-", Command: "resize-pane-shrink", Context: "conversations-main"},
 
 		// File browser tree context
 		{Key: "tab", Command: "switch-pane", Context: "file-browser-tree"},
 		{Key: "shift+tab", Command: "switch-pane", Context: "file-browser-tree"},
+		{Key: "l", Command: "focus-right", Context: "file-browser-tree"},
+		{Key: "right", Command: "focus-right", Context: "file-browser-tree"},
 		{Key: "/", Command: "search", Context: "file-browser-tree"},
 		{Key: "ctrl+p", Command: "quick-open", Context: "file-browser-tree"},
 		{Key: "f", Command: "project-search", Context: "file-browser-tree"},
@@ -268,6 +284,8 @@ func DefaultBindings() []Binding {
 		{Key: "B", Command: "blame", Context: "file-browser-tree"},
 		{Key: "\\", Command: "toggle-sidebar", Context: "file-browser-tree"},
 		{Key: "H", Command: "toggle-ignored", Context: "file-browser-tree"},
+		{Key: "+", Command: "resize-pane-grow", Context: "file-browser-tree"},
+		{Key: "-", Command: "resize-pane-shrink", Context: "file-browser-tree"},
 
 		// File browser preview context
 		{Key: "tab", Command: "switch-pane", Context: "file-browser-preview"},
@@ -292,6 +310,8 @@ func DefaultBindings() []Binding {
 		{Key: "Y", Command: "yank-path", Context: "file-browser-preview"},
 		{Key: "\\", Command: "toggle-sidebar", Context: "file-browser-preview"},
 		{Key: "w", Command: "toggle-wrap", Context: "file-browser-preview"},
+		{Key: "+", Command: "resize-pane-grow", Context: "file-browser-preview"},
+		{Key: "-", Command: "resize-pane-shrink", Context: "file-browser-preview"},
 
 		// File browser tree search context
 		{Key: "esc", Command: "cancel", Context: "file-browser-search"},
@@ -365,6 +385,8 @@ func DefaultBindings() []Binding {
 		{Key: "[", Command: "prev-tab", Context: "workspace-list"},
 		{Key: "]", Command: "next-tab", Context: "workspace-list"},
 		{Key: "F", Command: "fetch-pr", Context: "workspace-list"},
+		{Key: "+", Command: "resize-pane-grow", Context: "workspace-list"},
+		{Key: "-", Command: "resize-pane-shrink", Context: "workspace-list"},
 
 		// Workspace fetch PR context
 		{Key: "esc", Command: "cancel", Context: "workspace-fetch-pr"},
@@ -390,6 +412,8 @@ func DefaultBindings() []Binding {
 		{Key: "k", Command: "scroll-up", Context: "workspace-preview"},
 		{Key: "ctrl+d", Command: "page-down", Context: "workspace-preview"},
 		{Key: "ctrl+u", Command: "page-up", Context: "workspace-preview"},
+		{Key: "+", Command: "resize-pane-grow", Context: "workspace-preview"},
+		{Key: "-", Command: "resize-pane-shrink", Context: "workspace-preview"},
 
 		// Workspace merge error context
 		{Key: "esc", Command: "dismiss-merge-error", Context: "workspace-merge-error"},

--- a/internal/plugins/conversations/plugin_input.go
+++ b/internal/plugins/conversations/plugin_input.go
@@ -8,6 +8,7 @@ import (
 	"github.com/marcus/sidecar/internal/adapter"
 	appmsg "github.com/marcus/sidecar/internal/msg"
 	"github.com/marcus/sidecar/internal/plugin"
+	"github.com/marcus/sidecar/internal/state"
 )
 
 // Update methods for handling key events in various views
@@ -124,6 +125,28 @@ func (p *Plugin) updateSessions(msg tea.KeyMsg) (plugin.Plugin, tea.Cmd) {
 		p.toggleSidebar()
 		if !p.sidebarVisible {
 			return p, appmsg.ShowToast("Sidebar hidden (\\ to restore)", 2*time.Second)
+		}
+
+	case "+":
+		// Grow sidebar width
+		if p.sidebarVisible {
+			available := p.width - dividerWidth
+			maxWidth := available - 40
+			p.sidebarWidth += 3
+			if p.sidebarWidth > maxWidth {
+				p.sidebarWidth = maxWidth
+			}
+			_ = state.SetConversationsSideWidth(p.sidebarWidth)
+		}
+
+	case "-":
+		// Shrink sidebar width
+		if p.sidebarVisible {
+			p.sidebarWidth -= 3
+			if p.sidebarWidth < 25 {
+				p.sidebarWidth = 25
+			}
+			_ = state.SetConversationsSideWidth(p.sidebarWidth)
 		}
 
 	case "l", "right":
@@ -424,6 +447,30 @@ func (p *Plugin) updateMessages(msg tea.KeyMsg) (plugin.Plugin, tea.Cmd) {
 			p.activePane = PaneSidebar
 		} else {
 			p.activePane = PaneSidebar
+		}
+		return p, nil
+
+	case "+":
+		// Grow sidebar width (from main pane)
+		if p.sidebarVisible {
+			available := p.width - dividerWidth
+			maxWidth := available - 40
+			p.sidebarWidth += 3
+			if p.sidebarWidth > maxWidth {
+				p.sidebarWidth = maxWidth
+			}
+			_ = state.SetConversationsSideWidth(p.sidebarWidth)
+		}
+		return p, nil
+
+	case "-":
+		// Shrink sidebar width (from main pane)
+		if p.sidebarVisible {
+			p.sidebarWidth -= 3
+			if p.sidebarWidth < 25 {
+				p.sidebarWidth = 25
+			}
+			_ = state.SetConversationsSideWidth(p.sidebarWidth)
 		}
 		return p, nil
 

--- a/internal/plugins/filebrowser/handlers.go
+++ b/internal/plugins/filebrowser/handlers.go
@@ -370,6 +370,31 @@ func (p *Plugin) handleTreeKey(key string) (plugin.Plugin, tea.Cmd) {
 			p.activePane = PanePreview
 		}
 
+	case "+":
+		// Grow tree pane width
+		if p.treeVisible {
+			available := p.width - dividerWidth
+			maxWidth := available - 40
+			p.treeWidth += 3
+			if p.treeWidth > maxWidth {
+				p.treeWidth = maxWidth
+			}
+			p.previewWidth = available - p.treeWidth
+			_ = state.SetFileBrowserTreeWidth(p.treeWidth)
+		}
+
+	case "-":
+		// Shrink tree pane width
+		if p.treeVisible {
+			p.treeWidth -= 3
+			if p.treeWidth < 20 {
+				p.treeWidth = 20
+			}
+			available := p.width - dividerWidth
+			p.previewWidth = available - p.treeWidth
+			_ = state.SetFileBrowserTreeWidth(p.treeWidth)
+		}
+
 	case "\\":
 		// Toggle tree pane visibility
 		p.treeVisible = !p.treeVisible
@@ -459,6 +484,31 @@ func (p *Plugin) handlePreviewKey(key string) (plugin.Plugin, tea.Cmd) {
 		p.previewScroll -= visibleHeight
 		if p.previewScroll < 0 {
 			p.previewScroll = 0
+		}
+
+	case "+":
+		// Grow tree pane width (from preview pane)
+		if p.treeVisible {
+			available := p.width - dividerWidth
+			maxWidth := available - 40
+			p.treeWidth += 3
+			if p.treeWidth > maxWidth {
+				p.treeWidth = maxWidth
+			}
+			p.previewWidth = available - p.treeWidth
+			_ = state.SetFileBrowserTreeWidth(p.treeWidth)
+		}
+
+	case "-":
+		// Shrink tree pane width (from preview pane)
+		if p.treeVisible {
+			p.treeWidth -= 3
+			if p.treeWidth < 20 {
+				p.treeWidth = 20
+			}
+			available := p.width - dividerWidth
+			p.previewWidth = available - p.treeWidth
+			_ = state.SetFileBrowserTreeWidth(p.treeWidth)
 		}
 
 	case "h", "left", "esc":

--- a/internal/plugins/gitstatus/update_handlers.go
+++ b/internal/plugins/gitstatus/update_handlers.go
@@ -122,6 +122,31 @@ func (p *Plugin) updateStatus(msg tea.KeyMsg) (plugin.Plugin, tea.Cmd) {
 			p.activePane = PaneDiff
 		}
 
+	case "+":
+		// Grow sidebar width
+		if p.sidebarVisible {
+			available := p.width - dividerWidth
+			maxWidth := available - 40
+			p.sidebarWidth += 3
+			if p.sidebarWidth > maxWidth {
+				p.sidebarWidth = maxWidth
+			}
+			p.diffPaneWidth = available - p.sidebarWidth
+			_ = state.SetGitStatusSidebarWidth(p.sidebarWidth)
+		}
+
+	case "-":
+		// Shrink sidebar width
+		if p.sidebarVisible {
+			p.sidebarWidth -= 3
+			if p.sidebarWidth < 25 {
+				p.sidebarWidth = 25
+			}
+			available := p.width - dividerWidth
+			p.diffPaneWidth = available - p.sidebarWidth
+			_ = state.SetGitStatusSidebarWidth(p.sidebarWidth)
+		}
+
 	case "\\":
 		// Toggle sidebar visibility
 		p.toggleSidebar()
@@ -533,6 +558,31 @@ func (p *Plugin) updateStatusDiffPane(msg tea.KeyMsg) (plugin.Plugin, tea.Cmd) {
 			p.activePane = PaneSidebar
 		}
 
+	case "+":
+		// Grow sidebar width
+		if p.sidebarVisible {
+			available := p.width - dividerWidth
+			maxWidth := available - 40
+			p.sidebarWidth += 3
+			if p.sidebarWidth > maxWidth {
+				p.sidebarWidth = maxWidth
+			}
+			p.diffPaneWidth = available - p.sidebarWidth
+			_ = state.SetGitStatusSidebarWidth(p.sidebarWidth)
+		}
+
+	case "-":
+		// Shrink sidebar width
+		if p.sidebarVisible {
+			p.sidebarWidth -= 3
+			if p.sidebarWidth < 25 {
+				p.sidebarWidth = 25
+			}
+			available := p.width - dividerWidth
+			p.diffPaneWidth = available - p.sidebarWidth
+			_ = state.SetGitStatusSidebarWidth(p.sidebarWidth)
+		}
+
 	case "\\":
 		// Toggle sidebar visibility
 		p.toggleSidebar()
@@ -618,6 +668,31 @@ func (p *Plugin) updateCommitPreviewPane(msg tea.KeyMsg) (plugin.Plugin, tea.Cmd
 		// Switch focus to sidebar (if visible)
 		if p.sidebarVisible {
 			p.activePane = PaneSidebar
+		}
+
+	case "+":
+		// Grow sidebar width
+		if p.sidebarVisible {
+			available := p.width - dividerWidth
+			maxWidth := available - 40
+			p.sidebarWidth += 3
+			if p.sidebarWidth > maxWidth {
+				p.sidebarWidth = maxWidth
+			}
+			p.diffPaneWidth = available - p.sidebarWidth
+			_ = state.SetGitStatusSidebarWidth(p.sidebarWidth)
+		}
+
+	case "-":
+		// Shrink sidebar width
+		if p.sidebarVisible {
+			p.sidebarWidth -= 3
+			if p.sidebarWidth < 25 {
+				p.sidebarWidth = 25
+			}
+			available := p.width - dividerWidth
+			p.diffPaneWidth = available - p.sidebarWidth
+			_ = state.SetGitStatusSidebarWidth(p.sidebarWidth)
 		}
 
 	case "\\":

--- a/internal/plugins/workspace/keys.go
+++ b/internal/plugins/workspace/keys.go
@@ -690,6 +690,34 @@ func (p *Plugin) handleListKeys(msg tea.KeyMsg) tea.Cmd {
 		if p.activePane == PanePreview {
 			p.activePane = PaneSidebar
 		}
+	case "+":
+		// Grow sidebar width
+		if p.sidebarVisible {
+			p.sidebarWidth += 3
+			if p.sidebarWidth > 60 {
+				p.sidebarWidth = 60
+			}
+			_ = state.SetWorkspaceSidebarWidth(p.sidebarWidth)
+			if p.viewMode == ViewModeInteractive && p.interactiveState != nil && p.interactiveState.Active {
+				return tea.Batch(p.resizeInteractivePaneCmd(), p.pollInteractivePaneImmediate())
+			}
+			return p.resizeSelectedPaneCmd()
+		}
+
+	case "-":
+		// Shrink sidebar width
+		if p.sidebarVisible {
+			p.sidebarWidth -= 3
+			if p.sidebarWidth < 20 {
+				p.sidebarWidth = 20
+			}
+			_ = state.SetWorkspaceSidebarWidth(p.sidebarWidth)
+			if p.viewMode == ViewModeInteractive && p.interactiveState != nil && p.interactiveState.Active {
+				return tea.Batch(p.resizeInteractivePaneCmd(), p.pollInteractivePaneImmediate())
+			}
+			return p.resizeSelectedPaneCmd()
+		}
+
 	case "\\":
 		p.toggleSidebar()
 		if p.viewMode == ViewModeInteractive {


### PR DESCRIPTION
## Summary

Adds keyboard-driven pane resizing and fills in missing vim-style pane navigation across all two-pane plugins.

### Keyboard pane resizing (`+`/`-`)
- `+` grows the sidebar, `-` shrinks it (3 columns per keypress)
- Same clamping logic as drag-to-resize (min 20-25, max = available - 40)
- Width changes persisted to state automatically
- Works from both sidebar and detail pane contexts
- Applies to all 4 two-pane plugins: git status, file browser, conversations, workspace

### Vim-style pane focus (filling gaps)
 focus-right bindings for `git-status` and `file-browser-tree` contexts
- Bindings added to all 10 two-pane keymap contexts for `+`/`-`

### Files changed
- `internal/keymap/bindings. 24 new bindingsgo` 
- `internal/plugins/gitstatus/update_handlers. resize in sidebar, diff, and commit previewgo` 
- `internal/plugins/filebrowser/handlers. resize in tree and preview panesgo` 
- `internal/plugins/conversations/plugin_input. resize in sidebar and messages panesgo` 
- `internal/plugins/workspace/keys. resize with percentage-based width (20-60%)go` 
- `.claude/skills/keyboard-shortcuts/SKILL. documented new shortcutsmd` 

Closes marcus/sidecar#142