### PR TITLE
docs: add missing doc.go for pricing and notes packages

### DIFF
--- a/internal/adapter/pricing/doc.go
+++ b/internal/adapter/pricing/doc.go
@@ -1,0 +1,5 @@
+// Package pricing calculates API costs for Claude model usage based on
+// token counts. It classifies model IDs into pricing tiers by family
+// (Opus, Sonnet, Haiku) and version, then applies per-million-token
+// rates for input, output, cache-read, and cache-write tokens.
+package pricing

--- a/internal/plugins/notes/doc.go
+++ b/internal/plugins/notes/doc.go
@@ -1,0 +1,6 @@
+// Package notes implements a dual-pane notes plugin for sidecar.
+// It provides note creation, editing, deletion, and search with
+// persistent SQLite-backed storage. Notes can be filtered by status
+// (active, archived, deleted) and edited inline via a full-text
+// editor pane.
+package notes


### PR DESCRIPTION
## Summary
- Added `doc.go` for `internal/adapter/pricing` — documents the model cost calculation and tier classification logic
- Added `doc.go` for `internal/plugins/notes` — documents the dual-pane notes plugin with SQLite-backed storage

The other 3 packages identified (`migration`, `projectdir`, `tdroot`) already have package-level doc comments in their main `.go` files.

## Test plan
- [x] `go build` passes for both packages
- [x] `go test` passes for both packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: docs-backfill:/Users/marcusvorwaller/code/sidecar
task-type: docs-backfill
task-title: Documentation Backfiller
provider: claude
score: 6.0
cost-tier: Low (10-50k)
iterations: 1
duration: 7m55s
run-started: 2026-03-20T02:14:01-07:00
nightshift:metadata -->
