### PR TITLE
feat: add commit message normalizer

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,20 @@ type PluginsConfig struct {
 type GitStatusPluginConfig struct {
 	Enabled         bool          `json:"enabled"`
 	RefreshInterval time.Duration `json:"refreshInterval"`
+	Commit          CommitConfig  `json:"commit"`
+}
+
+// CommitConfig configures commit message normalization and validation.
+type CommitConfig struct {
+	// SubjectMaxLen is the maximum recommended length for the subject line (first line).
+	// Messages exceeding this show a warning but are not blocked. Default: 72.
+	SubjectMaxLen int `json:"subjectMaxLen"`
+	// ConventionalCommits enforces conventional commit prefixes (feat:, fix:, etc.).
+	// When true, commits without a recognized prefix are blocked. Default: false.
+	ConventionalCommits bool `json:"conventionalCommits"`
+	// AllowedPrefixes overrides the default conventional commit types.
+	// Default: ["feat", "fix", "docs", "style", "refactor", "perf", "test", "build", "ci", "chore", "revert"]
+	AllowedPrefixes []string `json:"allowedPrefixes,omitempty"`
 }
 
 // TDMonitorPluginConfig configures the TD monitor plugin.
@@ -121,6 +135,9 @@ func Default() *Config {
 			GitStatus: GitStatusPluginConfig{
 				Enabled:         true,
 				RefreshInterval: time.Second,
+				Commit: CommitConfig{
+					SubjectMaxLen: 72,
+				},
 			},
 			TDMonitor: TDMonitorPluginConfig{
 				Enabled:         true,

--- a/internal/plugins/gitstatus/commit_view.go
+++ b/internal/plugins/gitstatus/commit_view.go
@@ -155,7 +155,27 @@ func (p *Plugin) commitStagedSection() modal.Section {
 
 func (p *Plugin) commitStatusSection() modal.Section {
 	return modal.Custom(func(contentWidth int, focusID, hoverID string) modal.RenderedSection {
-		lines := make([]string, 0, 2)
+		lines := make([]string, 0, 4)
+
+		// Subject line length indicator.
+		subLen := SubjectLength(p.commitMessage.Value())
+		maxLen := p.commitConfig().SubjectMaxLen
+		if maxLen <= 0 {
+			maxLen = 72
+		}
+		lenStr := fmt.Sprintf("%d/%d", subLen, maxLen)
+		switch {
+		case subLen > maxLen:
+			lines = append(lines, styles.StatusDeleted.Render(lenStr))
+		case subLen > maxLen*3/4:
+			lines = append(lines, styles.StatusModified.Render(lenStr))
+		default:
+			lines = append(lines, styles.Muted.Render(lenStr))
+		}
+
+		if p.commitWarning != "" {
+			lines = append(lines, styles.StatusModified.Render("⚠ "+p.commitWarning))
+		}
 		if p.commitError != "" {
 			lines = append(lines, styles.StatusDeleted.Render("✗ "+p.commitError))
 		}

--- a/internal/plugins/gitstatus/normalize.go
+++ b/internal/plugins/gitstatus/normalize.go
@@ -1,0 +1,104 @@
+package gitstatus
+
+import (
+	"strings"
+
+	"github.com/marcus/sidecar/internal/config"
+)
+
+// DefaultAllowedPrefixes are the standard conventional commit types.
+var DefaultAllowedPrefixes = []string{
+	"feat", "fix", "docs", "style", "refactor",
+	"perf", "test", "build", "ci", "chore", "revert", "merge",
+}
+
+// NormalizeResult holds the normalized message and any warnings.
+type NormalizeResult struct {
+	Message  string
+	Warning  string // non-empty if subject exceeds max length
+	Error    string // non-empty if validation failed (e.g., missing prefix)
+}
+
+// NormalizeCommitMessage cleans up and validates a commit message.
+func NormalizeCommitMessage(raw string, cfg config.CommitConfig) NormalizeResult {
+	// Normalize line endings to LF.
+	msg := strings.ReplaceAll(raw, "\r\n", "\n")
+	msg = strings.ReplaceAll(msg, "\r", "\n")
+
+	// Split into lines and clean each one.
+	lines := strings.Split(msg, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t")
+	}
+
+	// Collapse consecutive blank lines into a single blank line.
+	collapsed := make([]string, 0, len(lines))
+	prevBlank := false
+	for _, line := range lines {
+		blank := line == ""
+		if blank && prevBlank {
+			continue
+		}
+		collapsed = append(collapsed, line)
+		prevBlank = blank
+	}
+
+	// Trim leading and trailing blank lines.
+	for len(collapsed) > 0 && collapsed[0] == "" {
+		collapsed = collapsed[1:]
+	}
+	for len(collapsed) > 0 && collapsed[len(collapsed)-1] == "" {
+		collapsed = collapsed[:len(collapsed)-1]
+	}
+
+	result := NormalizeResult{
+		Message: strings.Join(collapsed, "\n"),
+	}
+
+	if result.Message == "" {
+		result.Error = "Commit message cannot be empty"
+		return result
+	}
+
+	subject := collapsed[0]
+
+	// Check subject line length.
+	maxLen := cfg.SubjectMaxLen
+	if maxLen <= 0 {
+		maxLen = 72
+	}
+	if len(subject) > maxLen {
+		result.Warning = "Subject line exceeds recommended length"
+	}
+
+	// Check conventional commit prefix.
+	if cfg.ConventionalCommits {
+		prefixes := cfg.AllowedPrefixes
+		if len(prefixes) == 0 {
+			prefixes = DefaultAllowedPrefixes
+		}
+		if !hasConventionalPrefix(subject, prefixes) {
+			result.Error = "Missing conventional commit prefix (e.g., feat:, fix:)"
+		}
+	}
+
+	return result
+}
+
+// hasConventionalPrefix checks if subject starts with "type:" or "type(scope):".
+func hasConventionalPrefix(subject string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(subject, prefix+":") || strings.HasPrefix(subject, prefix+"(") {
+			return true
+		}
+	}
+	return false
+}
+
+// SubjectLength returns the length of the first line of a commit message.
+func SubjectLength(msg string) int {
+	if idx := strings.IndexByte(msg, '\n'); idx >= 0 {
+		return idx
+	}
+	return len(msg)
+}

--- a/internal/plugins/gitstatus/normalize_test.go
+++ b/internal/plugins/gitstatus/normalize_test.go
@@ -1,0 +1,146 @@
+package gitstatus
+
+import (
+	"testing"
+
+	"github.com/marcus/sidecar/internal/config"
+)
+
+func TestNormalizeCommitMessage(t *testing.T) {
+	defaultCfg := config.CommitConfig{SubjectMaxLen: 72}
+
+	tests := []struct {
+		name    string
+		raw     string
+		cfg     config.CommitConfig
+		wantMsg string
+		wantWrn string
+		wantErr string
+	}{
+		{
+			name:    "simple message unchanged",
+			raw:     "fix: resolve crash on startup",
+			cfg:     defaultCfg,
+			wantMsg: "fix: resolve crash on startup",
+		},
+		{
+			name:    "trims leading and trailing whitespace",
+			raw:     "\n\n  fix: trim test  \n\n",
+			cfg:     defaultCfg,
+			wantMsg: "  fix: trim test",
+		},
+		{
+			name:    "strips trailing whitespace per line",
+			raw:     "subject line   \n\nbody line   ",
+			cfg:     defaultCfg,
+			wantMsg: "subject line\n\nbody line",
+		},
+		{
+			name:    "collapses consecutive blank lines",
+			raw:     "subject\n\n\n\nbody paragraph",
+			cfg:     defaultCfg,
+			wantMsg: "subject\n\nbody paragraph",
+		},
+		{
+			name:    "normalizes CRLF to LF",
+			raw:     "subject\r\n\r\nbody",
+			cfg:     defaultCfg,
+			wantMsg: "subject\n\nbody",
+		},
+		{
+			name:    "normalizes CR to LF",
+			raw:     "subject\r\rbody",
+			cfg:     defaultCfg,
+			wantMsg: "subject\n\nbody",
+		},
+		{
+			name:    "empty message returns error",
+			raw:     "   \n\n  ",
+			cfg:     defaultCfg,
+			wantErr: "Commit message cannot be empty",
+		},
+		{
+			name:    "subject exceeds max length warns",
+			raw:     "feat: this is a very long commit message subject line that exceeds the seventy-two character limit by quite a bit",
+			cfg:     defaultCfg,
+			wantMsg: "feat: this is a very long commit message subject line that exceeds the seventy-two character limit by quite a bit",
+			wantWrn: "Subject line exceeds recommended length",
+		},
+		{
+			name:    "subject within max length no warning",
+			raw:     "feat: short subject",
+			cfg:     config.CommitConfig{SubjectMaxLen: 72},
+			wantMsg: "feat: short subject",
+		},
+		{
+			name:    "conventional commits enforced with valid prefix",
+			raw:     "feat: add feature",
+			cfg:     config.CommitConfig{SubjectMaxLen: 72, ConventionalCommits: true},
+			wantMsg: "feat: add feature",
+		},
+		{
+			name:    "conventional commits enforced with scope",
+			raw:     "fix(auth): resolve token bug",
+			cfg:     config.CommitConfig{SubjectMaxLen: 72, ConventionalCommits: true},
+			wantMsg: "fix(auth): resolve token bug",
+		},
+		{
+			name:    "conventional commits enforced missing prefix",
+			raw:     "add feature without prefix",
+			cfg:     config.CommitConfig{SubjectMaxLen: 72, ConventionalCommits: true},
+			wantMsg: "add feature without prefix",
+			wantErr: "Missing conventional commit prefix (e.g., feat:, fix:)",
+		},
+		{
+			name:    "custom allowed prefixes",
+			raw:     "hotfix: emergency patch",
+			cfg:     config.CommitConfig{SubjectMaxLen: 72, ConventionalCommits: true, AllowedPrefixes: []string{"hotfix", "release"}},
+			wantMsg: "hotfix: emergency patch",
+		},
+		{
+			name:    "custom prefixes rejects standard prefix",
+			raw:     "feat: new thing",
+			cfg:     config.CommitConfig{SubjectMaxLen: 72, ConventionalCommits: true, AllowedPrefixes: []string{"hotfix"}},
+			wantMsg: "feat: new thing",
+			wantErr: "Missing conventional commit prefix (e.g., feat:, fix:)",
+		},
+		{
+			name:    "multiline with body preserved",
+			raw:     "feat: add normalizer\n\nThis normalizes commit messages\nto ensure consistent formatting.",
+			cfg:     defaultCfg,
+			wantMsg: "feat: add normalizer\n\nThis normalizes commit messages\nto ensure consistent formatting.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NormalizeCommitMessage(tt.raw, tt.cfg)
+			if result.Message != tt.wantMsg {
+				t.Errorf("Message:\n got:  %q\nwant: %q", result.Message, tt.wantMsg)
+			}
+			if result.Warning != tt.wantWrn {
+				t.Errorf("Warning: got %q, want %q", result.Warning, tt.wantWrn)
+			}
+			if result.Error != tt.wantErr {
+				t.Errorf("Error: got %q, want %q", result.Error, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSubjectLength(t *testing.T) {
+	tests := []struct {
+		msg  string
+		want int
+	}{
+		{"single line", 11},
+		{"subject\n\nbody", 7},
+		{"", 0},
+		{"subject\nbody", 7},
+	}
+	for _, tt := range tests {
+		if got := SubjectLength(tt.msg); got != tt.want {
+			t.Errorf("SubjectLength(%q) = %d, want %d", tt.msg, got, tt.want)
+		}
+	}
+}

--- a/internal/plugins/gitstatus/plugin.go
+++ b/internal/plugins/gitstatus/plugin.go
@@ -141,6 +141,7 @@ type Plugin struct {
 	// Commit state
 	commitMessage         textarea.Model
 	commitError           string
+	commitWarning         string
 	commitInProgress      bool
 	commitAmend           bool // true when amending last commit
 	commitButtonFocus     bool // true when button is focused instead of textarea
@@ -461,6 +462,7 @@ func (p *Plugin) Update(msg tea.Msg) (plugin.Plugin, tea.Cmd) {
 		p.commitInProgress = false
 		p.commitAmend = false
 		p.commitError = ""
+		p.commitWarning = ""
 		return p, p.refresh()
 
 	case CommitErrorMsg:
@@ -1360,6 +1362,7 @@ func (p *Plugin) initCommitTextarea() {
 	p.commitMessage.SetWidth(textareaWidth)
 	p.commitMessage.SetHeight(4)
 	p.commitError = ""
+	p.commitWarning = ""
 	p.commitButtonFocus = false
 	p.commitButtonHover = false
 	p.commitModal = nil

--- a/internal/plugins/gitstatus/update_handlers.go
+++ b/internal/plugins/gitstatus/update_handlers.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/marcus/sidecar/internal/app"
+	"github.com/marcus/sidecar/internal/config"
 	appmsg "github.com/marcus/sidecar/internal/msg"
 	"github.com/marcus/sidecar/internal/plugin"
 	"github.com/marcus/sidecar/internal/state"
@@ -813,16 +814,31 @@ func (p *Plugin) updateCommit(msg tea.KeyMsg) (plugin.Plugin, tea.Cmd) {
 
 // tryCommit attempts to execute the commit (or amend) if message is valid.
 func (p *Plugin) tryCommit() tea.Cmd {
-	message := strings.TrimSpace(p.commitMessage.Value())
-	if message == "" {
-		p.commitError = "Commit message cannot be empty"
+	raw := p.commitMessage.Value()
+	cfg := p.commitConfig()
+	result := NormalizeCommitMessage(raw, cfg)
+
+	if result.Error != "" {
+		p.commitError = result.Error
 		return nil
 	}
+	if result.Warning != "" {
+		p.commitWarning = result.Warning
+	}
+
 	p.commitInProgress = true
 	if p.commitAmend {
-		return p.doAmend(message)
+		return p.doAmend(result.Message)
 	}
-	return p.doCommit(message)
+	return p.doCommit(result.Message)
+}
+
+// commitConfig returns the commit configuration, falling back to defaults.
+func (p *Plugin) commitConfig() config.CommitConfig {
+	if p.ctx != nil && p.ctx.Config != nil {
+		return p.ctx.Config.Plugins.GitStatus.Commit
+	}
+	return config.CommitConfig{SubjectMaxLen: 72}
 }
 
 // updatePushMenu handles key events in the push menu.


### PR DESCRIPTION
## Summary
- Adds commit message normalization (whitespace cleanup, blank line collapsing, LF normalization) applied automatically before `git commit`
- Adds configurable subject line length validation (default 72 chars) with real-time character count indicator in the commit modal
- Adds optional conventional commit prefix enforcement via `plugins.git-status.commit` config

## Test plan
- [x] Unit tests for `NormalizeCommitMessage` covering all normalization rules, edge cases, and conventional commit validation
- [x] Unit tests for `SubjectLength` helper
- [x] `go build ./...` passes
- [x] `go vet ./internal/plugins/gitstatus/...` passes
- [ ] Manual: open commit modal, verify character count appears and changes color at 75% and 100% of max length
- [ ] Manual: commit with trailing whitespace/blank lines and verify message is cleaned up
- [ ] Manual: set `conventionalCommits: true` in config and verify prefix enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/Users/marcusvorwaller/code/sidecar
task-type: commit-normalize
task-title: Commit Message Normalizer
provider: claude
nightshift:metadata -->