### PR TITLE
Fix clipboard in WSL by using atotto/clipboard

### DIFF
--- a/internal/plugins/tdmonitor/plugin.go
+++ b/internal/plugins/tdmonitor/plugin.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"time"
 
+	"github.com/atotto/clipboard"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/marcus/td/pkg/monitor"
@@ -118,6 +119,11 @@ func (p *Plugin) Init(ctx *plugin.Context) error {
 	}
 
 	p.model = model
+
+	// Use sidecar's clipboard (atotto/clipboard) instead of td's built-in one.
+	// td's copyToClipboard doesn't handle WSL (tries xclip/xsel only);
+	// atotto/clipboard falls through to clip.exe on WSL.
+	model.ClipboardFn = clipboard.WriteAll
 
 	// Register TD bindings with sidecar's keymap (single source of truth)
 	if ctx.Keymap != nil && model.Keymap != nil {

--- a/internal/plugins/tdmonitor/plugin_test.go
+++ b/internal/plugins/tdmonitor/plugin_test.go
@@ -3,6 +3,7 @@ package tdmonitor
 import (
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -156,6 +157,44 @@ func TestInitWithValidDatabase(t *testing.T) {
 
 	// Cleanup
 	p.Stop()
+}
+
+func TestInitSetsClipboardFn(t *testing.T) {
+	// Create a temp directory with a td database so we don't depend on
+	// the repo having one.
+	tmpDir, err := os.MkdirTemp("", "tdmonitor-clipboard-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Initialize td in the temp directory
+	cmd := exec.Command("td", "init")
+	cmd.Dir = tmpDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("td init failed (td not installed?): %s: %v", out, err)
+	}
+
+	p := New()
+	ctx := &plugin.Context{
+		WorkDir: tmpDir,
+		Logger:  slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+	}
+
+	if err := p.Init(ctx); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer p.Stop()
+
+	if p.model == nil {
+		t.Fatal("model should be created when database exists")
+	}
+
+	// ClipboardFn must be set so sidecar's clipboard (atotto/clipboard) is used
+	// instead of td's built-in one, which doesn't handle WSL.
+	if p.model.ClipboardFn == nil {
+		t.Error("model.ClipboardFn should be set to sidecar's clipboard implementation")
+	}
 }
 
 func TestDiagnosticsWithDatabase(t *testing.T) {


### PR DESCRIPTION
## Summary

- td's built-in `copyToClipboard` only tries `xclip`/`xsel` on Linux, which fails in WSL
- Sets `model.ClipboardFn` to use sidecar's existing `atotto/clipboard` dependency, which falls through to `clip.exe` on WSL
- Adds tests for the clipboard function integration

## Test plan

- [x] `go test ./internal/plugins/tdmonitor/...`
- [x] Verify clipboard copy works in WSL (copy a task ID, paste elsewhere)
- [ ] Verify clipboard copy still works on native Linux/macOS