### PR TITLE
feat: allow disabling plugins via config

### DIFF
--- a/cmd/sidecar/main.go
+++ b/cmd/sidecar/main.go
@@ -171,17 +171,25 @@ func main() {
 
 	// Register plugins (order determines tab order)
 	// TD plugin registers its bindings dynamically via p.ctx.Keymap
-	if err := registry.Register(tdmonitor.New()); err != nil {
-		logger.Warn("failed to register tdmonitor plugin", "err", err)
+	if cfg.Plugins.TDMonitor.Enabled {
+		if err := registry.Register(tdmonitor.New()); err != nil {
+			logger.Warn("failed to register tdmonitor plugin", "err", err)
+		}
 	}
-	if err := registry.Register(gitstatus.New()); err != nil {
-		logger.Warn("failed to register gitstatus plugin", "err", err)
+	if cfg.Plugins.GitStatus.Enabled {
+		if err := registry.Register(gitstatus.New()); err != nil {
+			logger.Warn("failed to register gitstatus plugin", "err", err)
+		}
 	}
-	if err := registry.Register(filebrowser.New()); err != nil {
-		logger.Warn("failed to register filebrowser plugin", "err", err)
+	if cfg.Plugins.FileBrowser.Enabled {
+		if err := registry.Register(filebrowser.New()); err != nil {
+			logger.Warn("failed to register filebrowser plugin", "err", err)
+		}
 	}
-	if err := registry.Register(conversations.New()); err != nil {
-		logger.Warn("failed to register conversations plugin", "err", err)
+	if cfg.Plugins.Conversations.Enabled {
+		if err := registry.Register(conversations.New()); err != nil {
+			logger.Warn("failed to register conversations plugin", "err", err)
+		}
 	}
 	if err := registry.Register(workspace.New()); err != nil {
 		logger.Warn("failed to register workspace plugin", "err", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,7 @@ type ProjectConfig struct {
 type PluginsConfig struct {
 	GitStatus     GitStatusPluginConfig     `json:"git-status"`
 	TDMonitor     TDMonitorPluginConfig     `json:"td-monitor"`
+	FileBrowser   FileBrowserPluginConfig   `json:"file-browser"`
 	Conversations ConversationsPluginConfig `json:"conversations"`
 	Workspace     WorkspacePluginConfig     `json:"workspace"`
 	Notes         NotesPluginConfig         `json:"notes"`
@@ -44,6 +45,12 @@ type PluginsConfig struct {
 type GitStatusPluginConfig struct {
 	Enabled         bool          `json:"enabled"`
 	RefreshInterval time.Duration `json:"refreshInterval"`
+}
+
+// FileBrowserPluginConfig configures the file browser plugin.
+type FileBrowserPluginConfig struct {
+	// Enabled controls whether the file browser plugin is loaded. Default: true.
+	Enabled bool `json:"enabled"`
 }
 
 // TDMonitorPluginConfig configures the TD monitor plugin.
@@ -148,6 +155,9 @@ func Default() *Config {
 				Enabled:         true,
 				RefreshInterval: 2 * time.Second,
 				DBPath:          ".todos/issues.db",
+			},
+			FileBrowser: FileBrowserPluginConfig{
+				Enabled: true,
 			},
 			Conversations: ConversationsPluginConfig{
 				Enabled:       true,

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -74,6 +74,7 @@ type rawProjectConfig struct {
 type rawPluginsConfig struct {
 	GitStatus     rawGitStatusConfig     `json:"git-status"`
 	TDMonitor     rawTDMonitorConfig     `json:"td-monitor"`
+	FileBrowser   rawFileBrowserConfig   `json:"file-browser"`
 	Conversations rawConversationsConfig `json:"conversations"`
 	Workspace     rawWorkspaceConfig     `json:"workspace"`
 }
@@ -107,6 +108,10 @@ type rawTDMonitorConfig struct {
 	Enabled         *bool  `json:"enabled"`
 	RefreshInterval string `json:"refreshInterval"`
 	DBPath          string `json:"dbPath"`
+}
+
+type rawFileBrowserConfig struct {
+	Enabled *bool `json:"enabled"`
 }
 
 type rawConversationsConfig struct {
@@ -215,6 +220,11 @@ func mergeConfig(cfg *Config, raw *rawConfig) {
 	}
 	if raw.Plugins.TDMonitor.DBPath != "" {
 		cfg.Plugins.TDMonitor.DBPath = raw.Plugins.TDMonitor.DBPath
+	}
+
+	// File Browser
+	if raw.Plugins.FileBrowser.Enabled != nil {
+		cfg.Plugins.FileBrowser.Enabled = *raw.Plugins.FileBrowser.Enabled
 	}
 
 	// Conversations

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -371,3 +371,40 @@ func TestApplyEnvOverrides_NeitherVarSet(t *testing.T) {
 		t.Errorf("DefaultAgentType = %q, want %q (should be unchanged)", cfg.Plugins.Workspace.DefaultAgentType, "original")
 	}
 }
+
+func TestDefault_FileBrowserEnabled(t *testing.T) {
+	cfg := Default()
+	if !cfg.Plugins.FileBrowser.Enabled {
+		t.Error("file-browser should be enabled by default")
+	}
+}
+
+func TestLoadFrom_FileBrowserDisabled(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	content := []byte(`{
+		"plugins": {
+			"file-browser": {
+				"enabled": false
+			}
+		}
+	}`)
+
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom failed: %v", err)
+	}
+
+	if cfg.Plugins.FileBrowser.Enabled {
+		t.Error("file-browser should be disabled when set to false in config")
+	}
+	// Other plugins should still have defaults
+	if !cfg.Plugins.GitStatus.Enabled {
+		t.Error("git-status should still be enabled (default)")
+	}
+}

--- a/internal/config/saver.go
+++ b/internal/config/saver.go
@@ -26,8 +26,13 @@ type saveProjectsConfig struct {
 type savePluginsConfig struct {
 	GitStatus     saveGitStatusConfig     `json:"git-status,omitempty"`
 	TDMonitor     saveTDMonitorConfig     `json:"td-monitor,omitempty"`
+	FileBrowser   saveFileBrowserConfig   `json:"file-browser,omitempty"`
 	Conversations saveConversationsConfig `json:"conversations,omitempty"`
 	Workspace     saveWorkspaceConfig     `json:"workspace,omitempty"`
+}
+
+type saveFileBrowserConfig struct {
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 type saveGitStatusConfig struct {
@@ -75,6 +80,9 @@ func toSaveConfig(cfg *Config) saveConfig {
 				Enabled:         &cfg.Plugins.TDMonitor.Enabled,
 				RefreshInterval: cfg.Plugins.TDMonitor.RefreshInterval.String(),
 				DBPath:          cfg.Plugins.TDMonitor.DBPath,
+			},
+			FileBrowser: saveFileBrowserConfig{
+				Enabled: &cfg.Plugins.FileBrowser.Enabled,
 			},
 			Conversations: saveConversationsConfig{
 				Enabled:       &cfg.Plugins.Conversations.Enabled,


### PR DESCRIPTION
Fixes #243.

## What
Wires the `enabled` config field for all registerable plugins in `main.go`, and adds a missing `FileBrowserPluginConfig` struct (the file-browser plugin had no config struct at all).

## Changes

- **`internal/config/config.go`**: Added `FileBrowserPluginConfig` with `Enabled` field. Added to `PluginsConfig`. Default is `true`.
- **`internal/config/loader.go`**: Added `rawFileBrowserConfig`, wired into `rawPluginsConfig`, merge logic in `mergeConfig`.
- **`internal/config/saver.go`**: Added `saveFileBrowserConfig`, wired into `savePluginsConfig` and `toSaveConfig`.
- **`cmd/sidecar/main.go`**: Wrapped each plugin registration with its `Enabled` check. Workspace remains unconditional (core plugin).
- **`internal/config/loader_test.go`**: Tests for default-enabled and config-disabled file-browser.

## Usage
```json
{
  "plugins": {
    "git-status": { "enabled": false },
    "file-browser": { "enabled": false },
    "td-monitor": { "enabled": false },
    "conversations": { "enabled": false }
  }
}
```

## Test
`go build ./...` and `go test ./...` pass clean.