### PR TITLE
feat: add commit message normalization

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,10 +40,19 @@ type PluginsConfig struct {
 	Notes         NotesPluginConfig         `json:"notes"`
 }
 
+// CommitConfig configures commit message normalization rules.
+type CommitConfig struct {
+	SubjectMaxLen          int  `json:"subjectMaxLen"`
+	EnforceBlankSecondLine bool `json:"enforceBlankSecondLine"`
+	AutoCapitalize         bool `json:"autoCapitalize"`
+	StripTrailingPeriod    bool `json:"stripTrailingPeriod"`
+}
+
 // GitStatusPluginConfig configures the git status plugin.
 type GitStatusPluginConfig struct {
 	Enabled         bool          `json:"enabled"`
 	RefreshInterval time.Duration `json:"refreshInterval"`
+	Commit          CommitConfig  `json:"commit"`
 }
 
 // TDMonitorPluginConfig configures the TD monitor plugin.
@@ -121,6 +130,12 @@ func Default() *Config {
 			GitStatus: GitStatusPluginConfig{
 				Enabled:         true,
 				RefreshInterval: time.Second,
+				Commit: CommitConfig{
+					SubjectMaxLen:          72,
+					EnforceBlankSecondLine: true,
+					AutoCapitalize:         true,
+					StripTrailingPeriod:    true,
+				},
 			},
 			TDMonitor: TDMonitorPluginConfig{
 				Enabled:         true,

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -86,9 +86,17 @@ type rawWorkspaceConfig struct {
 	InteractivePasteKey  string `json:"interactivePasteKey"`
 }
 
+type rawCommitConfig struct {
+	SubjectMaxLen          *int  `json:"subjectMaxLen"`
+	EnforceBlankSecondLine *bool `json:"enforceBlankSecondLine"`
+	AutoCapitalize         *bool `json:"autoCapitalize"`
+	StripTrailingPeriod    *bool `json:"stripTrailingPeriod"`
+}
+
 type rawGitStatusConfig struct {
-	Enabled         *bool  `json:"enabled"`
-	RefreshInterval string `json:"refreshInterval"`
+	Enabled         *bool           `json:"enabled"`
+	RefreshInterval string          `json:"refreshInterval"`
+	Commit          rawCommitConfig `json:"commit"`
 }
 
 type rawTDMonitorConfig struct {
@@ -179,6 +187,18 @@ func mergeConfig(cfg *Config, raw *rawConfig) {
 		if d, err := time.ParseDuration(raw.Plugins.GitStatus.RefreshInterval); err == nil {
 			cfg.Plugins.GitStatus.RefreshInterval = d
 		}
+	}
+	if raw.Plugins.GitStatus.Commit.SubjectMaxLen != nil {
+		cfg.Plugins.GitStatus.Commit.SubjectMaxLen = *raw.Plugins.GitStatus.Commit.SubjectMaxLen
+	}
+	if raw.Plugins.GitStatus.Commit.EnforceBlankSecondLine != nil {
+		cfg.Plugins.GitStatus.Commit.EnforceBlankSecondLine = *raw.Plugins.GitStatus.Commit.EnforceBlankSecondLine
+	}
+	if raw.Plugins.GitStatus.Commit.AutoCapitalize != nil {
+		cfg.Plugins.GitStatus.Commit.AutoCapitalize = *raw.Plugins.GitStatus.Commit.AutoCapitalize
+	}
+	if raw.Plugins.GitStatus.Commit.StripTrailingPeriod != nil {
+		cfg.Plugins.GitStatus.Commit.StripTrailingPeriod = *raw.Plugins.GitStatus.Commit.StripTrailingPeriod
 	}
 
 	// TD Monitor

--- a/internal/plugins/gitstatus/commit_normalize.go
+++ b/internal/plugins/gitstatus/commit_normalize.go
@@ -1,0 +1,75 @@
+package gitstatus
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/marcus/sidecar/internal/config"
+)
+
+// NormalizeCommitMessage applies configured normalization rules to a commit message.
+func NormalizeCommitMessage(msg string, cfg config.CommitConfig) string {
+	if msg == "" {
+		return msg
+	}
+
+	lines := strings.SplitAfter(msg, "\n")
+	// Rebuild without trailing newline markers for easier manipulation
+	parts := strings.Split(msg, "\n")
+
+	subject := parts[0]
+
+	if cfg.AutoCapitalize {
+		subject = capitalizeFirst(subject)
+	}
+
+	if cfg.StripTrailingPeriod {
+		subject = strings.TrimRight(subject, ".")
+	}
+
+	if cfg.SubjectMaxLen > 0 && len(subject) > cfg.SubjectMaxLen {
+		subject = truncateSubject(subject, cfg.SubjectMaxLen)
+	}
+
+	parts[0] = subject
+
+	// Ensure blank second line between subject and body
+	if cfg.EnforceBlankSecondLine && len(parts) > 1 {
+		if strings.TrimSpace(parts[1]) != "" {
+			// Insert blank line between subject and body
+			newParts := make([]string, 0, len(parts)+1)
+			newParts = append(newParts, parts[0], "")
+			newParts = append(newParts, parts[1:]...)
+			parts = newParts
+		}
+	}
+
+	_ = lines // suppress unused warning from earlier split
+	return strings.Join(parts, "\n")
+}
+
+// capitalizeFirst uppercases the first letter of s.
+func capitalizeFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	r, size := utf8.DecodeRuneInString(s)
+	if r == utf8.RuneError {
+		return s
+	}
+	return string(unicode.ToUpper(r)) + s[size:]
+}
+
+// truncateSubject truncates subject to maxLen, breaking at word boundary if possible.
+func truncateSubject(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	// Try to break at last space before maxLen
+	cut := s[:maxLen]
+	if idx := strings.LastIndex(cut, " "); idx > maxLen/2 {
+		return cut[:idx]
+	}
+	return cut
+}

--- a/internal/plugins/gitstatus/commit_normalize_test.go
+++ b/internal/plugins/gitstatus/commit_normalize_test.go
@@ -1,0 +1,154 @@
+package gitstatus
+
+import (
+	"testing"
+
+	"github.com/marcus/sidecar/internal/config"
+)
+
+func TestNormalizeCommitMessage(t *testing.T) {
+	defaultCfg := config.CommitConfig{
+		SubjectMaxLen:          72,
+		EnforceBlankSecondLine: true,
+		AutoCapitalize:         true,
+		StripTrailingPeriod:    true,
+	}
+
+	tests := []struct {
+		name string
+		msg  string
+		cfg  config.CommitConfig
+		want string
+	}{
+		{
+			name: "empty message",
+			msg:  "",
+			cfg:  defaultCfg,
+			want: "",
+		},
+		{
+			name: "capitalize first letter",
+			msg:  "fix bug in parser",
+			cfg:  defaultCfg,
+			want: "Fix bug in parser",
+		},
+		{
+			name: "already capitalized",
+			msg:  "Fix bug in parser",
+			cfg:  defaultCfg,
+			want: "Fix bug in parser",
+		},
+		{
+			name: "strip trailing period",
+			msg:  "Fix bug in parser.",
+			cfg:  defaultCfg,
+			want: "Fix bug in parser",
+		},
+		{
+			name: "strip multiple trailing periods",
+			msg:  "Fix bug...",
+			cfg:  defaultCfg,
+			want: "Fix bug",
+		},
+		{
+			name: "enforce blank second line",
+			msg:  "Fix bug\nThis is the body",
+			cfg:  defaultCfg,
+			want: "Fix bug\n\nThis is the body",
+		},
+		{
+			name: "blank second line already present",
+			msg:  "Fix bug\n\nThis is the body",
+			cfg:  defaultCfg,
+			want: "Fix bug\n\nThis is the body",
+		},
+		{
+			name: "truncate long subject at word boundary",
+			msg:  "This is a very long commit message subject that exceeds the maximum allowed length for subjects",
+			cfg: config.CommitConfig{
+				SubjectMaxLen:          50,
+				EnforceBlankSecondLine: true,
+				AutoCapitalize:         true,
+				StripTrailingPeriod:    true,
+			},
+			want: "This is a very long commit message subject that",
+		},
+		{
+			name: "all rules combined",
+			msg:  "fix the parser bug.\ndetailed explanation here",
+			cfg:  defaultCfg,
+			want: "Fix the parser bug\n\ndetailed explanation here",
+		},
+		{
+			name: "auto capitalize disabled",
+			msg:  "fix bug",
+			cfg: config.CommitConfig{
+				SubjectMaxLen:          72,
+				EnforceBlankSecondLine: true,
+				AutoCapitalize:         false,
+				StripTrailingPeriod:    true,
+			},
+			want: "fix bug",
+		},
+		{
+			name: "strip period disabled",
+			msg:  "Fix bug.",
+			cfg: config.CommitConfig{
+				SubjectMaxLen:          72,
+				EnforceBlankSecondLine: true,
+				AutoCapitalize:         true,
+				StripTrailingPeriod:    false,
+			},
+			want: "Fix bug.",
+		},
+		{
+			name: "blank line enforcement disabled",
+			msg:  "Fix bug\nBody text",
+			cfg: config.CommitConfig{
+				SubjectMaxLen:          72,
+				EnforceBlankSecondLine: false,
+				AutoCapitalize:         true,
+				StripTrailingPeriod:    true,
+			},
+			want: "Fix bug\nBody text",
+		},
+		{
+			name: "subject only no body",
+			msg:  "fix bug.",
+			cfg:  defaultCfg,
+			want: "Fix bug",
+		},
+		{
+			name: "multiline body preserved",
+			msg:  "fix bug.\n\nLine 1\nLine 2\nLine 3",
+			cfg:  defaultCfg,
+			want: "Fix bug\n\nLine 1\nLine 2\nLine 3",
+		},
+		{
+			name: "unicode first character",
+			msg:  "über cool feature",
+			cfg:  defaultCfg,
+			want: "Über cool feature",
+		},
+		{
+			name: "zero max length disables truncation",
+			msg:  "This is a very long subject line that would normally be truncated but max len is zero",
+			cfg: config.CommitConfig{
+				SubjectMaxLen:          0,
+				EnforceBlankSecondLine: true,
+				AutoCapitalize:         true,
+				StripTrailingPeriod:    true,
+			},
+			want: "This is a very long subject line that would normally be truncated but max len is zero",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeCommitMessage(tt.msg, tt.cfg)
+			if got != tt.want {
+				t.Errorf("NormalizeCommitMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/plugins/gitstatus/commit_view.go
+++ b/internal/plugins/gitstatus/commit_view.go
@@ -42,6 +42,7 @@ func (p *Plugin) ensureCommitModal() {
 		AddSection(p.commitStagedSection()).
 		AddSection(modal.Spacer()).
 		AddSection(modal.Textarea(commitMessageID, &p.commitMessage, 4)).
+		AddSection(p.commitSubjectLenSection()).
 		AddSection(modal.When(p.showCommitAmendToggle, modal.CheckboxDisplay("Amend last commit", &p.commitAmend, "ctrl+a"))).
 		AddSection(p.commitStatusSection()).
 		AddSection(modal.Buttons(
@@ -150,6 +151,25 @@ func (p *Plugin) commitStagedSection() modal.Section {
 		}
 
 		return modal.RenderedSection{Content: sb.String()}
+	}, nil)
+}
+
+func (p *Plugin) commitSubjectLenSection() modal.Section {
+	return modal.Custom(func(contentWidth int, focusID, hoverID string) modal.RenderedSection {
+		maxLen := 72
+		if p.ctx != nil && p.ctx.Config != nil && p.ctx.Config.Plugins.GitStatus.Commit.SubjectMaxLen > 0 {
+			maxLen = p.ctx.Config.Plugins.GitStatus.Commit.SubjectMaxLen
+		}
+
+		msg := p.commitMessage.Value()
+		subject := strings.SplitN(msg, "\n", 2)[0]
+		subjectLen := len(subject)
+
+		counter := fmt.Sprintf("%d/%d", subjectLen, maxLen)
+		if subjectLen > maxLen {
+			return modal.RenderedSection{Content: styles.StatusDeleted.Render(counter)}
+		}
+		return modal.RenderedSection{Content: styles.Muted.Render(counter)}
 	}, nil)
 }
 

--- a/internal/plugins/gitstatus/update_handlers.go
+++ b/internal/plugins/gitstatus/update_handlers.go
@@ -818,6 +818,9 @@ func (p *Plugin) tryCommit() tea.Cmd {
 		p.commitError = "Commit message cannot be empty"
 		return nil
 	}
+	if p.ctx != nil && p.ctx.Config != nil {
+		message = NormalizeCommitMessage(message, p.ctx.Config.Plugins.GitStatus.Commit)
+	}
 	p.commitInProgress = true
 	if p.commitAmend {
 		return p.doAmend(message)


### PR DESCRIPTION
## Summary
- Add `NormalizeCommitMessage()` that auto-capitalizes first letter, strips trailing period, ensures blank second line between subject/body, and truncates long subjects
- Rules are configurable via `plugins.git-status.commit` in config.json (SubjectMaxLen, EnforceBlankSecondLine, AutoCapitalize, StripTrailingPeriod)
- Wire normalization into `tryCommit()` so it runs transparently before commit/amend
- Add subject length counter indicator to commit modal that highlights red when over limit
- Table-driven tests covering all normalization rules and edge cases

## Test plan
- [x] `go test ./internal/plugins/gitstatus/...` passes
- [x] `go build ./...` succeeds
- [ ] Manual: open commit modal, type message with lowercase first letter → verify it commits capitalized
- [ ] Manual: type message with trailing period → verify period stripped
- [ ] Manual: verify subject length counter shows red when over 72 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/Users/marcusvorwaller/code/sidecar
task-type: commit-normalize
task-title: Commit Message Normalizer
provider: claude
score: 0.2
cost-tier: Low (10-50k)
iterations: 1
duration: 44m26s
run-started: 2026-03-25T02:13:10-07:00
nightshift:metadata -->
