### PR TITLE
fix: correct go install path in td not-installed screen

### DIFF
--- a/internal/plugins/tdmonitor/notinstalled.go
+++ b/internal/plugins/tdmonitor/notinstalled.go
@@ -261,7 +261,7 @@ func (m *NotInstalledModel) renderPitch() string {
 	b.WriteString(linkStyle.Render("https://marcus.github.io/td/"))
 	b.WriteString("\n\n")
 
-	installCmd := "brew install marcus/tap/td\n# or\ngo install github.com/marcus/td/cmd/td@latest\n\ntd init"
+	installCmd := "brew install marcus/tap/td\n# or\ngo install github.com/marcus/td@latest\n\ntd init"
 	b.WriteString(codeBoxStyle.Render(installCmd))
 
 	return b.String()


### PR DESCRIPTION
## Summary

- The not-installed screen shows `go install github.com/marcus/td/cmd/td@latest`, but td's `main.go` is at the repository root — the correct command is `go install github.com/marcus/td@latest`