### PR TITLE
feat: add agentFilter config to limit visible agents in selection UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,10 @@ Config file: `~/.config/sidecar/config.json`
     "td-monitor": { "enabled": true, "refreshInterval": "2s" },
     "conversations": { "enabled": true },
     "file-browser": { "enabled": true },
-    "workspaces": { "enabled": true }
+    "workspace": {
+      "defaultAgentType": "claude",
+      "agentFilter": ["claude", "codex", "copilot"]
+    }
   },
   "ui": {
     "showClock": true,
@@ -260,6 +263,15 @@ Config file: `~/.config/sidecar/config.json`
   }
 }
 ```
+
+### Workspace Plugin Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `defaultAgentType` | string | `"claude"` | Default agent selected when creating workspaces. Valid values: `claude`, `codex`, `copilot`, `gemini`, `cursor`, `opencode`, `pi`, `amp` |
+| `agentFilter` | string[] | `[]` (all agents) | Limits which agents appear in selection UIs. If empty or omitted, all agents are shown. "None (attach only)" is always available. |
+| `dirPrefix` | bool | `true` | Prefix workspace directories with repo name |
+| `agentStart` | object | `{}` | Map of agent type to custom startup command (e.g., `{"claude": "claude --profile fast"}`) |
 
 ## Contributing
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,6 +96,11 @@ type WorkspacePluginConfig struct {
 	InteractivePasteKey string `json:"interactivePasteKey,omitempty"`
 	// SidebarDisplay controls what information is shown in the workspace sidebar entries.
 	SidebarDisplay SidebarDisplayConfig `json:"sidebarDisplay"`
+	// AgentFilter limits which agents appear in selection UIs.
+	// If empty or not set, all agents are shown.
+	// Values are agent type IDs: "claude", "codex", "copilot", "gemini", "cursor", "opencode", "pi", "amp".
+	// "none" is always available regardless of this setting.
+	AgentFilter []string `json:"agentFilter,omitempty"`
 }
 
 // SidebarDisplayConfig controls visibility of workspace sidebar entry elements.

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -83,13 +83,14 @@ type rawWorkspaceConfig struct {
 	DirPrefix            *bool                    `json:"dirPrefix"`
 	DefaultAgentType     string                   `json:"defaultAgentType"`
 	LegacyDefaultAgent   string                   `json:"defaultAgent"` // Backward compatibility
-	AgentStart           json.RawMessage           `json:"agentStart"`
+	AgentStart           json.RawMessage          `json:"agentStart"`
 	TmuxCaptureMaxBytes  *int                     `json:"tmuxCaptureMaxBytes"`
 	InteractiveExitKey   string                   `json:"interactiveExitKey"`
 	InteractiveAttachKey string                   `json:"interactiveAttachKey"`
 	InteractiveCopyKey   string                   `json:"interactiveCopyKey"`
 	InteractivePasteKey  string                   `json:"interactivePasteKey"`
 	SidebarDisplay       *rawSidebarDisplayConfig `json:"sidebarDisplay"`
+	AgentFilter          []string                 `json:"agentFilter"`
 }
 
 type rawSidebarDisplayConfig struct {
@@ -250,6 +251,9 @@ func mergeConfig(cfg *Config, raw *rawConfig) {
 	}
 	if agentStart, ok := parseAgentStartOverrides(raw.Plugins.Workspace.AgentStart); ok {
 		cfg.Plugins.Workspace.AgentStart = agentStart
+	}
+	if len(raw.Plugins.Workspace.AgentFilter) > 0 {
+		cfg.Plugins.Workspace.AgentFilter = raw.Plugins.Workspace.AgentFilter
 	}
 	if raw.Plugins.Workspace.InteractiveExitKey != "" {
 		cfg.Plugins.Workspace.InteractiveExitKey = raw.Plugins.Workspace.InteractiveExitKey

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -408,3 +408,58 @@ func TestLoadFrom_FileBrowserDisabled(t *testing.T) {
 		t.Error("git-status should still be enabled (default)")
 	}
 }
+
+func TestLoadFrom_WorkspaceAgentFilter(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := []byte(`{
+		"plugins": {
+			"workspace": {
+				"agentFilter": ["claude", "codex", "copilot"]
+			}
+		}
+	}`)
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom failed: %v", err)
+	}
+
+	if len(cfg.Plugins.Workspace.AgentFilter) != 3 {
+		t.Errorf("AgentFilter length = %d, want 3", len(cfg.Plugins.Workspace.AgentFilter))
+	}
+	expected := []string{"claude", "codex", "copilot"}
+	for i, want := range expected {
+		if cfg.Plugins.Workspace.AgentFilter[i] != want {
+			t.Errorf("AgentFilter[%d] = %q, want %q", i, cfg.Plugins.Workspace.AgentFilter[i], want)
+		}
+	}
+}
+
+func TestLoadFrom_WorkspaceAgentFilter_Empty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := []byte(`{
+		"plugins": {
+			"workspace": {
+				"agentFilter": []
+			}
+		}
+	}`)
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom failed: %v", err)
+	}
+
+	// Empty array should not override (stays nil/empty)
+	if len(cfg.Plugins.Workspace.AgentFilter) != 0 {
+		t.Errorf("AgentFilter length = %d, want 0", len(cfg.Plugins.Workspace.AgentFilter))
+	}
+}

--- a/internal/plugins/conversations/plugin.go
+++ b/internal/plugins/conversations/plugin.go
@@ -18,6 +18,7 @@ import (
 	"github.com/marcus/sidecar/internal/modal"
 	"github.com/marcus/sidecar/internal/mouse"
 	"github.com/marcus/sidecar/internal/plugin"
+	"github.com/marcus/sidecar/internal/plugins/workspace"
 	"github.com/marcus/sidecar/internal/state"
 	"github.com/marcus/sidecar/internal/ui"
 )
@@ -240,6 +241,7 @@ type Plugin struct {
 	resumeNameInput       textinput.Model
 	resumeBaseBranchInput textinput.Model
 	resumeAgentIdx        int
+	resumeAgentOrder      []workspace.AgentType // Filtered agent order
 	resumeSkipPermissions bool
 	resumeFocus           int
 	resumeSession         *adapter.Session

--- a/internal/plugins/conversations/resume_modal.go
+++ b/internal/plugins/conversations/resume_modal.go
@@ -66,8 +66,12 @@ func (p *Plugin) ensureResumeModal() {
 	}
 
 	// Build agent selection list
-	agentItems := make([]modal.ListItem, len(workspace.AgentTypeOrder))
-	for i, at := range workspace.AgentTypeOrder {
+	agentOrder := p.resumeAgentOrder
+	if len(agentOrder) == 0 {
+		agentOrder = workspace.AgentTypeOrder
+	}
+	agentItems := make([]modal.ListItem, len(agentOrder))
+	for i, at := range agentOrder {
 		agentItems[i] = modal.ListItem{
 			ID:    fmt.Sprintf("%s%d", resumeAgentItemPrefix, i),
 			Label: workspace.AgentDisplayNames[at],
@@ -139,10 +143,14 @@ func (p *Plugin) shouldShowResumeSkipPerms() bool {
 	if !p.isResumeWorktreeMode() {
 		return false
 	}
-	if p.resumeAgentIdx < 0 || p.resumeAgentIdx >= len(workspace.AgentTypeOrder) {
+	agentOrder := p.resumeAgentOrder
+	if len(agentOrder) == 0 {
+		agentOrder = workspace.AgentTypeOrder
+	}
+	if p.resumeAgentIdx < 0 || p.resumeAgentIdx >= len(agentOrder) {
 		return false
 	}
-	agentType := workspace.AgentTypeOrder[p.resumeAgentIdx]
+	agentType := agentOrder[p.resumeAgentIdx]
 	if agentType == workspace.AgentNone {
 		return false
 	}
@@ -180,7 +188,11 @@ func (p *Plugin) handleResumeModalKeys(msg tea.KeyMsg) tea.Cmd {
 	if strings.HasPrefix(action, resumeAgentItemPrefix) {
 		var idx int
 		_, _ = fmt.Sscanf(action, resumeAgentItemPrefix+"%d", &idx)
-		if idx >= 0 && idx < len(workspace.AgentTypeOrder) {
+		agentOrder := p.resumeAgentOrder
+		if len(agentOrder) == 0 {
+			agentOrder = workspace.AgentTypeOrder
+		}
+		if idx >= 0 && idx < len(agentOrder) {
 			p.resumeAgentIdx = idx
 		}
 	}
@@ -217,7 +229,11 @@ func (p *Plugin) handleResumeModalMouse(msg tea.MouseMsg) tea.Cmd {
 	if strings.HasPrefix(action, resumeAgentItemPrefix) {
 		var idx int
 		_, _ = fmt.Sscanf(action, resumeAgentItemPrefix+"%d", &idx)
-		if idx >= 0 && idx < len(workspace.AgentTypeOrder) {
+		agentOrder := p.resumeAgentOrder
+		if len(agentOrder) == 0 {
+			agentOrder = workspace.AgentTypeOrder
+		}
+		if idx >= 0 && idx < len(agentOrder) {
 			p.resumeAgentIdx = idx
 		}
 	}
@@ -276,7 +292,8 @@ func (p *Plugin) openResumeModal() tea.Cmd {
 	p.resumeBaseBranchInput.CharLimit = 100
 
 	// Set default agent based on adapter
-	p.resumeAgentIdx = defaultAgentIdxForAdapter(session.AdapterID)
+	p.resumeAgentOrder = p.filteredAgentOrder()
+	p.resumeAgentIdx = p.defaultAgentIdxInOrder(session.AdapterID)
 	p.resumeSkipPermissions = false
 
 	// Clear cached modal to rebuild with new session
@@ -295,7 +312,45 @@ func (p *Plugin) resetResumeModal() {
 	p.resumeType = resumeTypeShell
 	p.resumeFocus = 0
 	p.resumeAgentIdx = 0
+	p.resumeAgentOrder = nil
 	p.resumeSkipPermissions = false
+}
+
+// filteredAgentOrder returns the agent order filtered by workspace config.
+// If agentFilter is empty, returns the full AgentTypeOrder.
+// AgentNone is always included at the end regardless of filter.
+func (p *Plugin) filteredAgentOrder() []workspace.AgentType {
+	if p.ctx == nil || p.ctx.Config == nil {
+		return workspace.AgentTypeOrder
+	}
+	filter := p.ctx.Config.Plugins.Workspace.AgentFilter
+	if len(filter) == 0 {
+		return workspace.AgentTypeOrder
+	}
+
+	// Build set of allowed agents from config
+	allowed := make(map[workspace.AgentType]bool, len(filter))
+	for _, id := range filter {
+		at := workspace.AgentType(id)
+		if _, ok := workspace.AgentDisplayNames[at]; ok && at != workspace.AgentNone {
+			allowed[at] = true
+		}
+	}
+
+	// Filter AgentTypeOrder to preserve ordering
+	result := make([]workspace.AgentType, 0, len(allowed)+1)
+	for _, at := range workspace.AgentTypeOrder {
+		if at == workspace.AgentNone {
+			continue // Add None at the end
+		}
+		if allowed[at] {
+			result = append(result, at)
+		}
+	}
+
+	// Always include None at the end
+	result = append(result, workspace.AgentNone)
+	return result
 }
 
 // executeResume sends the resume message to workspace plugin.
@@ -329,8 +384,12 @@ func (p *Plugin) executeResume() tea.Cmd {
 		if msg.BaseBranch == "" {
 			msg.BaseBranch = "HEAD"
 		}
-		if p.resumeAgentIdx >= 0 && p.resumeAgentIdx < len(workspace.AgentTypeOrder) {
-			msg.AgentType = workspace.AgentTypeOrder[p.resumeAgentIdx]
+		agentOrder := p.resumeAgentOrder
+		if len(agentOrder) == 0 {
+			agentOrder = workspace.AgentTypeOrder
+		}
+		if p.resumeAgentIdx >= 0 && p.resumeAgentIdx < len(agentOrder) {
+			msg.AgentType = agentOrder[p.resumeAgentIdx]
 		}
 		msg.SkipPerms = p.resumeSkipPermissions
 	}
@@ -361,8 +420,8 @@ func (p *Plugin) getSessionForResume() *adapter.Session {
 	return nil
 }
 
-// defaultAgentIdxForAdapter returns the index in AgentTypeOrder for the given adapter.
-func defaultAgentIdxForAdapter(adapterID string) int {
+// defaultAgentIdxInOrder returns the index in resumeAgentOrder for the given adapter.
+func (p *Plugin) defaultAgentIdxInOrder(adapterID string) int {
 	var agentType workspace.AgentType
 	switch adapterID {
 	case "claude-code":
@@ -378,11 +437,14 @@ func defaultAgentIdxForAdapter(adapterID string) int {
 	case "pi-agent", "pi":
 		agentType = workspace.AgentPi
 	default:
-		return 0 // Default to first (Claude)
+		return 0 // Default to first agent
 	}
 
-	// Find index in AgentTypeOrder
-	for i, at := range workspace.AgentTypeOrder {
+	agentOrder := p.resumeAgentOrder
+	if len(agentOrder) == 0 {
+		agentOrder = workspace.AgentTypeOrder
+	}
+	for i, at := range agentOrder {
 		if at == agentType {
 			return i
 		}

--- a/internal/plugins/workspace/agent_config_modal.go
+++ b/internal/plugins/workspace/agent_config_modal.go
@@ -26,8 +26,9 @@ func (p *Plugin) openAgentConfigModal(wt *Worktree, isRestart bool) {
 	configDir := filepath.Join(home, ".config", "sidecar")
 	p.agentConfigWorktree = wt
 	p.agentConfigIsRestart = isRestart
+	p.agentConfigAgentOrder = p.filteredAgentOrder()
 	p.agentConfigAgentType = p.resolveWorktreeAgentType(wt)
-	p.agentConfigAgentIdx = p.agentTypeIndex(p.agentConfigAgentType)
+	p.agentConfigAgentIdx = p.agentConfigTypeIndex(p.agentConfigAgentType)
 	p.agentConfigSkipPerms = false
 	p.agentConfigPromptIdx = -1
 	p.agentConfigPrompts = LoadPrompts(configDir, p.ctx.ProjectRoot)
@@ -36,12 +37,27 @@ func (p *Plugin) openAgentConfigModal(wt *Worktree, isRestart bool) {
 	p.viewMode = ViewModeAgentConfig
 }
 
+// agentConfigTypeIndex returns the index of the agent type in agentConfigAgentOrder.
+func (p *Plugin) agentConfigTypeIndex(agentType AgentType) int {
+	agentOrder := p.agentConfigAgentOrder
+	if len(agentOrder) == 0 {
+		agentOrder = AgentTypeOrder
+	}
+	for i, at := range agentOrder {
+		if at == agentType {
+			return i
+		}
+	}
+	return 0
+}
+
 // clearAgentConfigModal resets all agent config modal state.
 func (p *Plugin) clearAgentConfigModal() {
 	p.agentConfigWorktree = nil
 	p.agentConfigIsRestart = false
 	p.agentConfigAgentType = ""
 	p.agentConfigAgentIdx = 0
+	p.agentConfigAgentOrder = nil
 	p.agentConfigSkipPerms = false
 	p.agentConfigPromptIdx = -1
 	p.agentConfigPrompts = nil
@@ -95,8 +111,12 @@ func (p *Plugin) ensureAgentConfigModal() {
 	}
 	p.agentConfigModalWidth = modalW
 
-	items := make([]modal.ListItem, len(AgentTypeOrder))
-	for i, at := range AgentTypeOrder {
+	agentOrder := p.agentConfigAgentOrder
+	if len(agentOrder) == 0 {
+		agentOrder = AgentTypeOrder
+	}
+	items := make([]modal.ListItem, len(agentOrder))
+	for i, at := range agentOrder {
 		items[i] = modal.ListItem{
 			ID:    fmt.Sprintf("%s%d", agentConfigAgentItemPrefix, i),
 			Label: AgentDisplayNames[at],

--- a/internal/plugins/workspace/agent_config_modal_test.go
+++ b/internal/plugins/workspace/agent_config_modal_test.go
@@ -45,13 +45,14 @@ func TestGetAgentConfigPrompt(t *testing.T) {
 
 func TestClearAgentConfigModal(t *testing.T) {
 	p := &Plugin{
-		agentConfigWorktree:  &Worktree{Name: "test"},
-		agentConfigIsRestart: true,
-		agentConfigAgentType: AgentClaude,
-		agentConfigAgentIdx:  3,
-		agentConfigSkipPerms: true,
-		agentConfigPromptIdx: 2,
-		agentConfigPrompts:   []Prompt{{Name: "x"}},
+		agentConfigWorktree:   &Worktree{Name: "test"},
+		agentConfigIsRestart:  true,
+		agentConfigAgentType:  AgentClaude,
+		agentConfigAgentIdx:   3,
+		agentConfigAgentOrder: []AgentType{AgentClaude, AgentCodex},
+		agentConfigSkipPerms:  true,
+		agentConfigPromptIdx:  2,
+		agentConfigPrompts:    []Prompt{{Name: "x"}},
 	}
 	p.clearAgentConfigModal()
 
@@ -66,6 +67,9 @@ func TestClearAgentConfigModal(t *testing.T) {
 	}
 	if p.agentConfigAgentIdx != 0 {
 		t.Error("agentIdx not cleared")
+	}
+	if p.agentConfigAgentOrder != nil {
+		t.Error("agentOrder not cleared")
 	}
 	if p.agentConfigSkipPerms {
 		t.Error("skipPerms not cleared")

--- a/internal/plugins/workspace/agent_filter_test.go
+++ b/internal/plugins/workspace/agent_filter_test.go
@@ -1,0 +1,187 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/marcus/sidecar/internal/config"
+	"github.com/marcus/sidecar/internal/plugin"
+)
+
+func TestFilteredAgentOrder(t *testing.T) {
+	tests := []struct {
+		name         string
+		filter       []string
+		wantLen      int
+		wantContains []AgentType
+		wantMissing  []AgentType
+	}{
+		{
+			name:         "empty filter returns all",
+			filter:       nil,
+			wantLen:      len(AgentTypeOrder),
+			wantContains: []AgentType{AgentClaude, AgentCodex, AgentNone},
+		},
+		{
+			name:         "single agent plus none",
+			filter:       []string{"claude"},
+			wantLen:      2,
+			wantContains: []AgentType{AgentClaude, AgentNone},
+			wantMissing:  []AgentType{AgentCodex, AgentCopilot},
+		},
+		{
+			name:         "multiple agents plus none",
+			filter:       []string{"claude", "codex", "copilot"},
+			wantLen:      4,
+			wantContains: []AgentType{AgentClaude, AgentCodex, AgentCopilot, AgentNone},
+			wantMissing:  []AgentType{AgentGemini, AgentCursor},
+		},
+		{
+			name:         "invalid agent IDs ignored",
+			filter:       []string{"claude", "invalid", "notreal"},
+			wantLen:      2,
+			wantContains: []AgentType{AgentClaude, AgentNone},
+		},
+		{
+			name:         "none in filter is ignored (always added at end)",
+			filter:       []string{"claude", ""},
+			wantLen:      2,
+			wantContains: []AgentType{AgentClaude, AgentNone},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Plugin{
+				ctx: &plugin.Context{
+					Config: &config.Config{
+						Plugins: config.PluginsConfig{
+							Workspace: config.WorkspacePluginConfig{
+								AgentFilter: tt.filter,
+							},
+						},
+					},
+				},
+			}
+
+			got := p.filteredAgentOrder()
+
+			if len(got) != tt.wantLen {
+				t.Errorf("filteredAgentOrder() len = %d, want %d", len(got), tt.wantLen)
+			}
+
+			for _, want := range tt.wantContains {
+				found := false
+				for _, g := range got {
+					if g == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("filteredAgentOrder() missing %q", want)
+				}
+			}
+
+			for _, notWant := range tt.wantMissing {
+				for _, g := range got {
+					if g == notWant {
+						t.Errorf("filteredAgentOrder() should not contain %q", notWant)
+					}
+				}
+			}
+
+			// None should always be last
+			if len(got) > 0 && got[len(got)-1] != AgentNone {
+				t.Errorf("filteredAgentOrder() last element = %q, want AgentNone", got[len(got)-1])
+			}
+		})
+	}
+}
+
+func TestFilteredShellAgentOrder(t *testing.T) {
+	tests := []struct {
+		name         string
+		filter       []string
+		wantLen      int
+		wantContains []AgentType
+		wantMissing  []AgentType
+	}{
+		{
+			name:         "empty filter returns all",
+			filter:       nil,
+			wantLen:      len(ShellAgentOrder),
+			wantContains: []AgentType{AgentNone, AgentClaude, AgentCodex},
+		},
+		{
+			name:         "filtered list has none first",
+			filter:       []string{"claude", "codex"},
+			wantLen:      3,
+			wantContains: []AgentType{AgentNone, AgentClaude, AgentCodex},
+			wantMissing:  []AgentType{AgentGemini, AgentCopilot},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Plugin{
+				ctx: &plugin.Context{
+					Config: &config.Config{
+						Plugins: config.PluginsConfig{
+							Workspace: config.WorkspacePluginConfig{
+								AgentFilter: tt.filter,
+							},
+						},
+					},
+				},
+			}
+
+			got := p.filteredShellAgentOrder()
+
+			if len(got) != tt.wantLen {
+				t.Errorf("filteredShellAgentOrder() len = %d, want %d", len(got), tt.wantLen)
+			}
+
+			for _, want := range tt.wantContains {
+				found := false
+				for _, g := range got {
+					if g == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("filteredShellAgentOrder() missing %q", want)
+				}
+			}
+
+			for _, notWant := range tt.wantMissing {
+				for _, g := range got {
+					if g == notWant {
+						t.Errorf("filteredShellAgentOrder() should not contain %q", notWant)
+					}
+				}
+			}
+
+			// None should always be first for shells
+			if len(got) > 0 && got[0] != AgentNone {
+				t.Errorf("filteredShellAgentOrder() first element = %q, want AgentNone", got[0])
+			}
+		})
+	}
+}
+
+func TestFilteredAgentOrder_NilContext(t *testing.T) {
+	p := &Plugin{ctx: nil}
+	got := p.filteredAgentOrder()
+	if len(got) != len(AgentTypeOrder) {
+		t.Errorf("with nil ctx, should return full AgentTypeOrder")
+	}
+}
+
+func TestFilteredAgentOrder_NilConfig(t *testing.T) {
+	p := &Plugin{ctx: &plugin.Context{Config: nil}}
+	got := p.filteredAgentOrder()
+	if len(got) != len(AgentTypeOrder) {
+		t.Errorf("with nil config, should return full AgentTypeOrder")
+	}
+}

--- a/internal/plugins/workspace/create_modal.go
+++ b/internal/plugins/workspace/create_modal.go
@@ -55,8 +55,12 @@ func (p *Plugin) ensureCreateModal() {
 	}
 	p.createModalWidth = modalW
 
-	items := make([]modal.ListItem, len(AgentTypeOrder))
-	for i, at := range AgentTypeOrder {
+	agentOrder := p.createAgentOrder
+	if len(agentOrder) == 0 {
+		agentOrder = AgentTypeOrder
+	}
+	items := make([]modal.ListItem, len(agentOrder))
+	for i, at := range agentOrder {
 		items[i] = modal.ListItem{
 			ID:    createIndexedID(createAgentItemPrefix, i),
 			Label: AgentDisplayNames[at],
@@ -119,11 +123,15 @@ func (p *Plugin) normalizeCreateFocus() {
 }
 
 func (p *Plugin) syncCreateAgentIdx() {
-	if p.createAgentIdx < 0 || p.createAgentIdx >= len(AgentTypeOrder) {
+	agentOrder := p.createAgentOrder
+	if len(agentOrder) == 0 {
+		agentOrder = AgentTypeOrder
+	}
+	if p.createAgentIdx < 0 || p.createAgentIdx >= len(agentOrder) {
 		p.createAgentIdx = p.agentTypeIndex(p.createAgentType)
 		return
 	}
-	if AgentTypeOrder[p.createAgentIdx] != p.createAgentType {
+	if agentOrder[p.createAgentIdx] != p.createAgentType {
 		p.createAgentIdx = p.agentTypeIndex(p.createAgentType)
 	}
 }

--- a/internal/plugins/workspace/keys.go
+++ b/internal/plugins/workspace/keys.go
@@ -70,8 +70,12 @@ func (p *Plugin) handleTypeSelectorKeys(msg tea.KeyMsg) tea.Cmd {
 
 	// Sync agent type when agent index changes (td-f42a86)
 	// No need to rebuild modal - When sections handle visibility dynamically
-	if p.typeSelectorAgentIdx != prevAgentIdx && p.typeSelectorAgentIdx >= 0 && p.typeSelectorAgentIdx < len(ShellAgentOrder) {
-		p.typeSelectorAgentType = ShellAgentOrder[p.typeSelectorAgentIdx]
+	agentOrder := p.typeSelectorAgentOrder
+	if len(agentOrder) == 0 {
+		agentOrder = ShellAgentOrder
+	}
+	if p.typeSelectorAgentIdx != prevAgentIdx && p.typeSelectorAgentIdx >= 0 && p.typeSelectorAgentIdx < len(agentOrder) {
+		p.typeSelectorAgentType = agentOrder[p.typeSelectorAgentIdx]
 	}
 
 	switch action {
@@ -326,8 +330,12 @@ func (p *Plugin) handleAgentConfigKeys(msg tea.KeyMsg) tea.Cmd {
 
 	// Sync agent type when selection changes
 	if p.agentConfigAgentIdx != prevAgentIdx {
-		if p.agentConfigAgentIdx >= 0 && p.agentConfigAgentIdx < len(AgentTypeOrder) {
-			p.agentConfigAgentType = AgentTypeOrder[p.agentConfigAgentIdx]
+		agentOrder := p.agentConfigAgentOrder
+		if len(agentOrder) == 0 {
+			agentOrder = AgentTypeOrder
+		}
+		if p.agentConfigAgentIdx >= 0 && p.agentConfigAgentIdx < len(agentOrder) {
+			p.agentConfigAgentType = agentOrder[p.agentConfigAgentIdx]
 		}
 	}
 
@@ -725,8 +733,9 @@ func (p *Plugin) handleListKeys(msg tea.KeyMsg) tea.Cmd {
 		p.typeSelectorNameInput.Prompt = ""
 		p.typeSelectorNameInput.Width = 30
 		p.typeSelectorNameInput.CharLimit = 50
-		p.typeSelectorModal = nil    // Force rebuild
-		p.typeSelectorModalWidth = 0 // Force rebuild
+		p.typeSelectorAgentOrder = p.filteredShellAgentOrder() // Initialize filtered agent order
+		p.typeSelectorModal = nil                              // Force rebuild
+		p.typeSelectorModalWidth = 0                           // Force rebuild
 		return nil
 	case "D":
 		// Check if deleting a shell session
@@ -1313,8 +1322,12 @@ func (p *Plugin) handleCreateKeys(msg tea.KeyMsg) tea.Cmd {
 
 	wasAgentIdx := p.createAgentIdx
 	action, cmd := p.createModal.HandleKey(msg)
-	if p.createAgentIdx != wasAgentIdx && p.createAgentIdx < len(AgentTypeOrder) {
-		p.createAgentType = AgentTypeOrder[p.createAgentIdx]
+	agentOrder := p.createAgentOrder
+	if len(agentOrder) == 0 {
+		agentOrder = AgentTypeOrder
+	}
+	if p.createAgentIdx != wasAgentIdx && p.createAgentIdx < len(agentOrder) {
+		p.createAgentType = agentOrder[p.createAgentIdx]
 		p.syncCreateModalFocus()
 	}
 
@@ -1379,7 +1392,11 @@ func (p *Plugin) shouldShowShellSkipPerms() bool {
 }
 
 func (p *Plugin) agentTypeIndex(agentType AgentType) int {
-	for i, at := range AgentTypeOrder {
+	agentOrder := p.createAgentOrder
+	if len(agentOrder) == 0 {
+		agentOrder = AgentTypeOrder
+	}
+	for i, at := range agentOrder {
 		if at == agentType {
 			return i
 		}

--- a/internal/plugins/workspace/mouse.go
+++ b/internal/plugins/workspace/mouse.go
@@ -168,9 +168,13 @@ func (p *Plugin) handleCreateModalMouse(msg tea.MouseMsg) tea.Cmd {
 		p.syncCreateModalFocus()
 		return nil
 	}
-	if idx, ok := parseIndexedID(createAgentItemPrefix, action); ok && idx < len(AgentTypeOrder) {
+	agentOrder := p.createAgentOrder
+	if len(agentOrder) == 0 {
+		agentOrder = AgentTypeOrder
+	}
+	if idx, ok := parseIndexedID(createAgentItemPrefix, action); ok && idx < len(agentOrder) {
 		p.createAgentIdx = idx
-		p.createAgentType = AgentTypeOrder[idx]
+		p.createAgentType = agentOrder[idx]
 		p.createFocus = 4
 		p.syncCreateModalFocus()
 		return nil
@@ -335,8 +339,12 @@ func (p *Plugin) handleAgentConfigModalMouse(msg tea.MouseMsg) tea.Cmd {
 
 	// Sync agent type when list selection changes via mouse
 	if p.agentConfigAgentIdx != prevAgentIdx {
-		if p.agentConfigAgentIdx >= 0 && p.agentConfigAgentIdx < len(AgentTypeOrder) {
-			p.agentConfigAgentType = AgentTypeOrder[p.agentConfigAgentIdx]
+		agentOrder := p.agentConfigAgentOrder
+		if len(agentOrder) == 0 {
+			agentOrder = AgentTypeOrder
+		}
+		if p.agentConfigAgentIdx >= 0 && p.agentConfigAgentIdx < len(agentOrder) {
+			p.agentConfigAgentType = agentOrder[p.agentConfigAgentIdx]
 		}
 	}
 
@@ -829,9 +837,13 @@ func (p *Plugin) handleMouseClick(action mouse.MouseAction) tea.Cmd {
 		}
 	case regionCreateAgentOption:
 		// Click on agent option
+		agentOrder := p.createAgentOrder
+		if len(agentOrder) == 0 {
+			agentOrder = AgentTypeOrder
+		}
 		if idx, ok := action.Region.Data.(int); ok {
-			if idx >= 0 && idx < len(AgentTypeOrder) {
-				p.createAgentType = AgentTypeOrder[idx]
+			if idx >= 0 && idx < len(agentOrder) {
+				p.createAgentType = agentOrder[idx]
 			}
 		}
 	case regionCreateCheckbox:

--- a/internal/plugins/workspace/plugin.go
+++ b/internal/plugins/workspace/plugin.go
@@ -224,10 +224,11 @@ type Plugin struct {
 	createNameInput       textinput.Model
 	createBaseBranchInput textinput.Model
 	createTaskID          string
-	createTaskTitle       string    // Title of selected task for display
-	createAgentType       AgentType // Selected agent type (default: AgentClaude)
-	createAgentIdx        int       // Selected agent index in AgentTypeOrder
-	createSkipPermissions bool      // Skip permissions checkbox
+	createTaskTitle       string      // Title of selected task for display
+	createAgentType       AgentType   // Selected agent type (default: AgentClaude)
+	createAgentIdx        int         // Selected agent index in createAgentOrder
+	createAgentOrder      []AgentType // Filtered agent order for create modal
+	createSkipPermissions bool        // Skip permissions checkbox
 	createFocus           int       // 0=name, 1=base, 2=prompt, 3=task, 4=agent, 5=skipPerms, 6=create, 7=cancel
 	createButtonHover     int       // 0=none, 1=create, 2=cancel
 	createError           string    // Error message to display in create modal
@@ -294,15 +295,16 @@ type Plugin struct {
 	agentChoiceModalWidth int          // Cached width for rebuild detection
 
 	// Agent config modal state (start/restart with options)
-	agentConfigWorktree   *Worktree
-	agentConfigIsRestart  bool
-	agentConfigAgentType  AgentType
-	agentConfigAgentIdx   int
-	agentConfigSkipPerms  bool
-	agentConfigPromptIdx  int
-	agentConfigPrompts    []Prompt
-	agentConfigModal      *modal.Modal
-	agentConfigModalWidth int
+	agentConfigWorktree    *Worktree
+	agentConfigIsRestart   bool
+	agentConfigAgentType   AgentType
+	agentConfigAgentIdx    int
+	agentConfigAgentOrder  []AgentType // Filtered agent order for agent config modal
+	agentConfigSkipPerms   bool
+	agentConfigPromptIdx   int
+	agentConfigPrompts     []Prompt
+	agentConfigModal       *modal.Modal
+	agentConfigModalWidth  int
 
 	// Prompt picker return routing
 	promptPickerReturnMode ViewMode
@@ -359,10 +361,11 @@ type Plugin struct {
 	typeSelectorModalWidth int             // Cached width for rebuild detection
 
 	// Type selector modal - shell agent selection (td-2bb232)
-	typeSelectorAgentIdx   int       // Selected index in agent list (0 = None)
-	typeSelectorAgentType  AgentType // The selected agent type
-	typeSelectorSkipPerms  bool      // Whether skip permissions is checked
-	typeSelectorFocusField int       // Focus: 0=name, 1=agent, 2=skipPerms, 3=buttons
+	typeSelectorAgentIdx   int         // Selected index in agent list (0 = None)
+	typeSelectorAgentType  AgentType   // The selected agent type
+	typeSelectorAgentOrder []AgentType // Filtered agent order for shell creation
+	typeSelectorSkipPerms  bool        // Whether skip permissions is checked
+	typeSelectorFocusField int         // Focus: 0=name, 1=agent, 2=skipPerms, 3=buttons
 
 	// Resume conversation state (td-aa4136)
 	pendingResumeCmd      string // Resume command to inject after shell creation
@@ -854,6 +857,80 @@ func (p *Plugin) getConfigDefaultAgentType() AgentType {
 	return AgentClaude
 }
 
+// filteredAgentOrder returns the agent order filtered by config.
+// If agentFilter is empty, returns the full AgentTypeOrder.
+// AgentNone is always included at the end regardless of filter.
+func (p *Plugin) filteredAgentOrder() []AgentType {
+	if p == nil || p.ctx == nil || p.ctx.Config == nil {
+		return AgentTypeOrder
+	}
+	filter := p.ctx.Config.Plugins.Workspace.AgentFilter
+	if len(filter) == 0 {
+		return AgentTypeOrder
+	}
+
+	// Build set of allowed agents from config
+	allowed := make(map[AgentType]bool, len(filter))
+	for _, id := range filter {
+		at := AgentType(id)
+		if _, ok := AgentDisplayNames[at]; ok && at != AgentNone {
+			allowed[at] = true
+		}
+	}
+
+	// Filter AgentTypeOrder to preserve ordering
+	result := make([]AgentType, 0, len(allowed)+1)
+	for _, at := range AgentTypeOrder {
+		if at == AgentNone {
+			continue // Add None at the end
+		}
+		if allowed[at] {
+			result = append(result, at)
+		}
+	}
+
+	// Always include None at the end
+	result = append(result, AgentNone)
+	return result
+}
+
+// filteredShellAgentOrder returns the agent order for shell creation filtered by config.
+// If agentFilter is empty, returns the full ShellAgentOrder (None first).
+// AgentNone is always included at the beginning regardless of filter.
+func (p *Plugin) filteredShellAgentOrder() []AgentType {
+	if p == nil || p.ctx == nil || p.ctx.Config == nil {
+		return ShellAgentOrder
+	}
+	filter := p.ctx.Config.Plugins.Workspace.AgentFilter
+	if len(filter) == 0 {
+		return ShellAgentOrder
+	}
+
+	// Build set of allowed agents from config
+	allowed := make(map[AgentType]bool, len(filter))
+	for _, id := range filter {
+		at := AgentType(id)
+		if _, ok := AgentDisplayNames[at]; ok && at != AgentNone {
+			allowed[at] = true
+		}
+	}
+
+	// Start with None (shells default to no agent)
+	result := []AgentType{AgentNone}
+
+	// Filter ShellAgentOrder to preserve ordering (skip None, already added)
+	for _, at := range ShellAgentOrder {
+		if at == AgentNone {
+			continue
+		}
+		if allowed[at] {
+			result = append(result, at)
+		}
+	}
+
+	return result
+}
+
 // resolveWorktreeAgentType returns the agent type to use when starting an agent for a worktree.
 // Hierarchy: .sidecar-agent file -> config defaultAgentType -> Claude fallback.
 func (p *Plugin) resolveWorktreeAgentType(wt *Worktree) AgentType {
@@ -885,6 +962,7 @@ func (p *Plugin) clearCreateModal() {
 	p.createBaseBranchInput = textinput.Model{}
 	p.createTaskID = ""
 	p.createTaskTitle = ""
+	p.createAgentOrder = nil
 	p.createAgentType = p.getDefaultCreateAgentType()
 	p.createAgentIdx = p.agentTypeIndex(p.createAgentType)
 	p.createSkipPermissions = false
@@ -937,6 +1015,7 @@ func (p *Plugin) initCreateModalBase() {
 	// Reset all state
 	p.createTaskID = ""
 	p.createTaskTitle = ""
+	p.createAgentOrder = p.filteredAgentOrder()
 	p.createAgentType = p.getDefaultCreateAgentType()
 	p.createAgentIdx = p.agentTypeIndex(p.createAgentType)
 	p.createSkipPermissions = false

--- a/internal/plugins/workspace/view_modals.go
+++ b/internal/plugins/workspace/view_modals.go
@@ -1212,8 +1212,12 @@ func (p *Plugin) ensureTypeSelectorModal() {
 	p.typeSelectorNameInput.Placeholder = p.nextShellDisplayName()
 
 	// Build agent list items for shell (td-a902fe)
-	agentItems := make([]modal.ListItem, len(ShellAgentOrder))
-	for i, at := range ShellAgentOrder {
+	agentOrder := p.typeSelectorAgentOrder
+	if len(agentOrder) == 0 {
+		agentOrder = ShellAgentOrder
+	}
+	agentItems := make([]modal.ListItem, len(agentOrder))
+	for i, at := range agentOrder {
 		agentItems[i] = modal.ListItem{
 			ID:    typeSelectorAgentItemPfx + string(at),
 			Label: AgentDisplayNames[at],
@@ -1282,6 +1286,7 @@ func (p *Plugin) clearTypeSelectorModal() {
 	// Reset shell agent selection state (td-2bb232)
 	p.typeSelectorAgentIdx = 0
 	p.typeSelectorAgentType = AgentNone
+	p.typeSelectorAgentOrder = nil
 	p.typeSelectorSkipPerms = false
 	p.typeSelectorFocusField = 0
 }


### PR DESCRIPTION
User story (my commentary 😆 )
> It was driving me crazy, especially when I wasn't plugged into a big monitor having to scroll the dialogue. So I implemented a filter to show only the agents that I use so that I can only show like Copilot and Claude.

## Summary

Add a new config option `agentFilter` under `plugins.workspace` that allows users to specify which AI agents appear in agent selection UIs.

## Problem

When creating workspaces or shells, users see all 8+ available agents in the selection list. Users who only use a subset of agents (ex: Claude, Codex, and Copilot) have to scroll through agents they never use.

## Solution

Add a config option to filter which agents are shown:

```json
{
  "plugins": {
    "workspace": {
      "agentFilter": ["claude", "codex", "copilot"]
    }
  }
}
```

### Behavior
- When `agentFilter` is set, only those agents plus "None (attach only)" are shown
- When `agentFilter` is empty or not set, all agents are shown (backward compatible)
- Invalid agent IDs in the filter are silently ignored
- "None" is always available regardless of filter

### Applies to
- ✅ Create Worktree modal
- ✅ Create Shell modal (type selector)
- ✅ Agent Config modal (start/restart agent)
- ✅ Conversations Resume modal

## Changes

| File | Description |
|------|-------------|
| `internal/config/config.go` | Add `AgentFilter []string` field |
| `internal/config/loader.go` | Add parsing and merge logic |
| `internal/plugins/workspace/plugin.go` | Add `filteredAgentOrder()` and `filteredShellAgentOrder()` helpers |
| `internal/plugins/workspace/create_modal.go` | Use filtered agent list |
| `internal/plugins/workspace/agent_config_modal.go` | Use filtered agent list |
| `internal/plugins/workspace/view_modals.go` | Use filtered agent list for shell creation |
| `internal/plugins/workspace/keys.go` | Update key handlers for filtered lists |
| `internal/plugins/workspace/mouse.go` | Update mouse handlers for filtered lists |
| `internal/plugins/conversations/resume_modal.go` | Use filtered agent list |
| `README.md` | Document new config option |

## Testing

- Added `agent_filter_test.go` with comprehensive tests for filter functions
- Added config loader tests for `agentFilter` parsing
- Updated `agent_config_modal_test.go` to verify new field clearing
- All existing tests pass

## Valid Agent IDs

`claude`, `codex`, `copilot`, `gemini`, `cursor`, `opencode`, `pi`, `amp`
