### PR TITLE
docs: add package-level doc.go for pricing and notes

### DIFF
--- a/internal/adapter/pricing/doc.go
+++ b/internal/adapter/pricing/doc.go
@@ -1,0 +1,6 @@
+// Package pricing calculates token costs for Claude API models.
+//
+// It maps model ID strings (e.g. "claude-opus-4-6-20260101") to version-aware
+// pricing tiers and computes dollar costs from token usage. Cache read and
+// cache write tokens are priced as fractions of the base input rate.
+package pricing

--- a/internal/plugins/notes/doc.go
+++ b/internal/plugins/notes/doc.go
@@ -1,0 +1,7 @@
+// Package notes implements a two-pane notes plugin for sidecar.
+//
+// Notes are persisted in SQLite (co-located with td's issues.db) and support
+// fuzzy search, pin/archive/soft-delete, undo, auto-save, and inline vim
+// editing via a tmux PTY backend. The left pane is a filterable note list;
+// the right pane shows a read-only preview or a full editor.
+package notes


### PR DESCRIPTION
## Summary
- Add `doc.go` for `internal/adapter/pricing` documenting version-aware pricing tiers and `ModelCost` entry point
- Add `doc.go` for `internal/plugins/notes` documenting the two-pane UI, SQLite storage, search, undo, and auto-save capabilities
- All existing exports already had doc comments; no additional export comments needed

## Test plan
- [x] `go build ./internal/adapter/pricing/ ./internal/plugins/notes/` passes
- [x] `go vet ./internal/adapter/pricing/ ./internal/plugins/notes/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)