### PR TITLE
fix: auto-format and fix compile errors

### DIFF
--- a/internal/adapter/opencode/adapter_test.go
+++ b/internal/adapter/opencode/adapter_test.go
@@ -146,7 +146,6 @@ func TestFindProjectID_WithSandboxPaths(t *testing.T) {
 	a := &Adapter{
 		storageDir:   tmpDir,
 		projectIndex: make(map[string]*Project),
-		sessionIndex: make(map[string]string),
 		metaCache:    make(map[string]sessionMetaCacheEntry),
 	}
 
@@ -208,7 +207,6 @@ func TestFindProjectID_SubdirectoryMatch(t *testing.T) {
 	a := &Adapter{
 		storageDir:   tmpDir,
 		projectIndex: make(map[string]*Project),
-		sessionIndex: make(map[string]string),
 		metaCache:    make(map[string]sessionMetaCacheEntry),
 	}
 
@@ -266,7 +264,6 @@ func TestFindProjectID_SandboxNotDuplicated(t *testing.T) {
 	a := &Adapter{
 		storageDir:   tmpDir,
 		projectIndex: make(map[string]*Project),
-		sessionIndex: make(map[string]string),
 		metaCache:    make(map[string]sessionMetaCacheEntry),
 	}
 


### PR DESCRIPTION
## Summary
- Auto-format 92 files with `gofmt -w` to fix formatting inconsistencies
- Fix compile error in `internal/adapter/opencode/adapter_test.go`: remove `sessionIndex` field from 3 Adapter struct literals (field was removed from Adapter struct but test code still referenced it)
- Verified with `go vet ./...`, `staticcheck ./...`, `go build ./...`, and `go test` (affected packages pass)

## Test plan
- [x] `gofmt -l .` returns 0 files
- [x] `go vet ./...` passes (no errors)
- [x] `go build ./...` succeeds
- [x] `go test ./internal/adapter/opencode/...` passes
- [x] `staticcheck ./...` shows only pre-existing SA6002 warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)