### PR TITLE
fix: remove deleted sessionIndex field from opencode adapter tests

### DIFF
--- a/internal/adapter/opencode/adapter_test.go
+++ b/internal/adapter/opencode/adapter_test.go
@@ -146,7 +146,6 @@ func TestFindProjectID_WithSandboxPaths(t *testing.T) {
 	a := &Adapter{
 		storageDir:   tmpDir,
 		projectIndex: make(map[string]*Project),
-		sessionIndex: make(map[string]string),
 		metaCache:    make(map[string]sessionMetaCacheEntry),
 	}
 
@@ -208,7 +207,6 @@ func TestFindProjectID_SubdirectoryMatch(t *testing.T) {
 	a := &Adapter{
 		storageDir:   tmpDir,
 		projectIndex: make(map[string]*Project),
-		sessionIndex: make(map[string]string),
 		metaCache:    make(map[string]sessionMetaCacheEntry),
 	}
 
@@ -266,7 +264,6 @@ func TestFindProjectID_SandboxNotDuplicated(t *testing.T) {
 	a := &Adapter{
 		storageDir:   tmpDir,
 		projectIndex: make(map[string]*Project),
-		sessionIndex: make(map[string]string),
 		metaCache:    make(map[string]sessionMetaCacheEntry),
 	}
 


### PR DESCRIPTION
## Summary
- Remove references to deleted `sessionIndex` field in 3 test struct literals in `internal/adapter/opencode/adapter_test.go`
- The field was removed from the `Adapter` struct but test code still referenced it, causing compile errors (`go vet` / `go build` failures)

## Verification
- `go vet ./...` passes clean
- `go build ./...` passes clean
- `go test ./internal/adapter/opencode/...` passes clean
- All other adapter tests pass (except pre-existing `TestSearchMessages_NonExistentSession` hang in warp adapter, unrelated)

## Test plan
- [x] `go vet ./...` — no errors
- [x] `go build ./...` — compiles successfully
- [x] `go test ./internal/adapter/opencode/...` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: lint-fix:/Users/marcusvorwaller/code/sidecar
task-type: lint-fix
task-title: Linter Fixes
provider: claude
score: 1.1
cost-tier: Low (10-50k)
iterations: 3
duration: 1h6m31s
run-started: 2026-03-29T02:03:47-07:00
nightshift:metadata -->
