### PR TITLE
fix: use tmpfile to avoid bash 3.2 apostrophe bug in agent launcher

### DIFF
--- a/internal/plugins/workspace/agent.go
+++ b/internal/plugins/workspace/agent.go
@@ -603,24 +603,30 @@ fi
 	switch agentType {
 	case AgentAider:
 		// aider uses --message flag
+		// Use tmpfile to avoid bash 3.2 bug: apostrophes in heredoc inside $(...) break parsing on macOS.
 		script = fmt.Sprintf(`#!/bin/bash
 %s
-%s --message "$(cat <<'SIDECAR_PROMPT_EOF'
+TMPFILE=$(mktemp /tmp/sidecar-prompt.XXXXXX)
+cat > "$TMPFILE" <<'SIDECAR_PROMPT_EOF'
 %s
 SIDECAR_PROMPT_EOF
-)"
+%s --message "$(cat "$TMPFILE")"
+rm -f "$TMPFILE"
 rm -f %q
-`, shellSetup, baseCmd, prompt, launcherFile)
+`, shellSetup, prompt, baseCmd, launcherFile)
 	case AgentOpenCode:
 		// opencode uses 'run' subcommand
+		// Use tmpfile to avoid bash 3.2 bug: apostrophes in heredoc inside $(...) break parsing on macOS.
 		script = fmt.Sprintf(`#!/bin/bash
 %s
-%s run "$(cat <<'SIDECAR_PROMPT_EOF'
+TMPFILE=$(mktemp /tmp/sidecar-prompt.XXXXXX)
+cat > "$TMPFILE" <<'SIDECAR_PROMPT_EOF'
 %s
 SIDECAR_PROMPT_EOF
-)"
+%s run "$(cat "$TMPFILE")"
+rm -f "$TMPFILE"
 rm -f %q
-`, shellSetup, baseCmd, prompt, launcherFile)
+`, shellSetup, prompt, baseCmd, launcherFile)
 	case AgentAmp:
 		// amp requires piping via stdin, does not accept positional args
 		script = fmt.Sprintf(`#!/bin/bash
@@ -631,15 +637,18 @@ SIDECAR_PROMPT_EOF
 rm -f %q
 `, shellSetup, baseCmd, prompt, launcherFile)
 	default:
-		// Most agents (claude, codex, gemini, cursor) take prompt as positional argument
+		// Most agents (claude, codex, gemini, cursor) take prompt as positional argument.
+		// Use tmpfile to avoid bash 3.2 bug: apostrophes in heredoc inside $(...) break parsing on macOS.
 		script = fmt.Sprintf(`#!/bin/bash
 %s
-%s "$(cat <<'SIDECAR_PROMPT_EOF'
+TMPFILE=$(mktemp /tmp/sidecar-prompt.XXXXXX)
+cat > "$TMPFILE" <<'SIDECAR_PROMPT_EOF'
 %s
 SIDECAR_PROMPT_EOF
-)"
+%s "$(cat "$TMPFILE")"
+rm -f "$TMPFILE"
 rm -f %q
-`, shellSetup, baseCmd, prompt, launcherFile)
+`, shellSetup, prompt, baseCmd, launcherFile)
 	}
 
 	if err := os.WriteFile(launcherFile, []byte(script), 0700); err != nil {

--- a/internal/plugins/workspace/agent_test.go
+++ b/internal/plugins/workspace/agent_test.go
@@ -1137,6 +1137,13 @@ func TestWriteAgentLauncher(t *testing.T) {
 			prompt:    "Task: fix bug",
 			wantCmd:   "bash '" + expectedLauncherPath + "'",
 		},
+		{
+			name:      "claude with apostrophe in prompt (bash 3.2 regression)",
+			agentType: AgentClaude,
+			baseCmd:   "claude",
+			prompt:    "fix today's bug — don't break it",
+			wantCmd:   "bash '" + expectedLauncherPath + "'",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1185,6 +1192,17 @@ func TestWriteAgentLauncher(t *testing.T) {
 			if tt.agentType == AgentAmp {
 				if !strings.Contains(scriptStr, "SIDECAR_PROMPT_EOF' | "+tt.baseCmd) {
 					t.Errorf("amp script should pipe prompt to command via stdin, got:\n%s", scriptStr)
+				}
+			} else {
+				// Non-Amp agents use the tmpfile pattern (safe on macOS bash 3.2 with apostrophes).
+				if !strings.Contains(scriptStr, "TMPFILE=$(mktemp") {
+					t.Errorf("script should use tmpfile pattern, got:\n%s", scriptStr)
+				}
+				if !strings.Contains(scriptStr, `cat > "$TMPFILE" <<'SIDECAR_PROMPT_EOF'`) {
+					t.Errorf("script should write prompt to tmpfile via heredoc, got:\n%s", scriptStr)
+				}
+				if !strings.Contains(scriptStr, `"$(cat "$TMPFILE")"`) {
+					t.Errorf("script should read prompt from tmpfile, got:\n%s", scriptStr)
 				}
 			}
 


### PR DESCRIPTION
## Problem

`writeAgentLauncher` generates `start.sh` scripts using a heredoc nested inside a `$(...)` command substitution:

```bash
claude "$(cat <<'SIDECAR_PROMPT_EOF'
...prompt with today's apostrophe...
SIDECAR_PROMPT_EOF
)"
```

macOS ships bash 3.2 (GPL2 constraint). Bash 3.2 has a known lexer bug: when scanning ahead for the closing `)"`, it incorrectly tracks single-quote state across the heredoc body. Any apostrophe in the prompt — `today's`, `don't`, `it's` — causes:

```
start.sh: line N: unexpected EOF while looking for matching `''
start.sh: line N: syntax error: unexpected end of file
```

This silently breaks agent launch for any task description containing an apostrophe, which is extremely common.

## Fix

Replace the nested heredoc with a tmpfile approach — write the prompt via a top-level heredoc (safe on all bash versions), then read it with a plain `$(cat "$TMPFILE")`:

```bash
TMPFILE=$(mktemp /tmp/sidecar-prompt.XXXXXX)
cat > "$TMPFILE" <<'SIDECAR_PROMPT_EOF'
...prompt with today's apostrophe...
SIDECAR_PROMPT_EOF
claude "$(cat "$TMPFILE")"
rm -f "$TMPFILE"
```

Applied to `AgentAider`, `AgentOpenCode`, and the default case. `AgentAmp` is unaffected — it already uses top-level stdin piping.

A regression test case with apostrophes in the prompt is included, along with assertions that non-Amp scripts use the tmpfile pattern.

---

*A note on provenance: I'm not a Go programmer — I'm just an avid and very happy Sidecar user who hit this bug. This fix was written with Claude Code (with me pointing it at the bug report and reviewing the output). I've done my best to follow the project's patterns and test conventions, but please scrutinise the diff accordingly. Happy to iterate if anything's off.*