### PR TITLE
fix(conversations): let g/G be typed into the session search box

### DIFF
--- a/internal/plugins/conversations/plugin_input.go
+++ b/internal/plugins/conversations/plugin_input.go
@@ -351,23 +351,10 @@ func (p *Plugin) updateSearch(msg tea.KeyPressMsg) (plugin.Plugin, tea.Cmd) {
 			return p, p.schedulePreviewLoad(p.selectedSession)
 		}
 
-	case "g":
-		p.cursor = 0
-		p.scrollOff = 0
-		sessions := p.visibleSessions()
-		if len(sessions) > 0 {
-			p.setSelectedSession(sessions[0].ID)
-			return p, p.schedulePreviewLoad(p.selectedSession)
-		}
-
-	case "G":
-		sessions := p.visibleSessions()
-		if len(sessions) > 0 {
-			p.cursor = len(sessions) - 1
-			p.ensureCursorVisible()
-			p.setSelectedSession(sessions[p.cursor].ID)
-			return p, p.schedulePreviewLoad(p.selectedSession)
-		}
+	// Note: 'g'/'G' goto-top/bottom are intentionally NOT bound here so they
+	// fall through to the default branch and are typed into the search query
+	// (issue #166). This mirrors the arrow-key-only navigation precedent
+	// (td-2467e8) already applied to up/down/h in the search input.
 
 	default:
 		// Add character to search query

--- a/internal/plugins/conversations/plugin_test.go
+++ b/internal/plugins/conversations/plugin_test.go
@@ -804,6 +804,46 @@ func TestUpdateSearchBackspace(t *testing.T) {
 	}
 }
 
+// TestUpdateSearchTypingGoto verifies that 'g' and 'G' are typed into the
+// search query instead of being swallowed by list goto-top/bottom navigation
+// while the search input is active (issue #166). Mirrors the arrow-key-only
+// navigation precedent (td-2467e8) already applied to up/down/h in this view.
+func TestUpdateSearchTypingGoto(t *testing.T) {
+	p := New()
+	p.adapters = map[string]adapter.Adapter{"mock": &mockAdapter{}}
+	p.sessions = []adapter.Session{
+		{ID: "test-1", Name: "go-build"},
+		{ID: "test-2", Name: "Golang"},
+		{ID: "test-3", Name: "other"},
+	}
+	p.searchMode = true
+
+	// Type 'g' — must land in the query, not trigger goto-top.
+	msg := tea.KeyPressMsg{Code: 'g', Text: "g"}
+	_, _ = p.Update(msg)
+
+	if p.searchQuery != "g" {
+		t.Errorf("expected 'g' to be typed into searchQuery, got %q (likely swallowed by goto-top navigation)", p.searchQuery)
+	}
+
+	// Type 'o' — completing "go", the exact scenario from issue #166.
+	msg = tea.KeyPressMsg{Code: 'o', Text: "o"}
+	_, _ = p.Update(msg)
+
+	if p.searchQuery != "go" {
+		t.Errorf("expected searchQuery 'go', got %q", p.searchQuery)
+	}
+
+	// 'G' (shift+g) must also be typed, not trigger goto-bottom.
+	p.searchQuery = ""
+	msg = tea.KeyPressMsg{Code: 'G', Text: "G"}
+	_, _ = p.Update(msg)
+
+	if p.searchQuery != "G" {
+		t.Errorf("expected 'G' to be typed into searchQuery, got %q (likely swallowed by goto-bottom navigation)", p.searchQuery)
+	}
+}
+
 // TestUpdateSearchNavigationDown tests down navigation in search results.
 func TestUpdateSearchNavigationDown(t *testing.T) {
 	p := New()


### PR DESCRIPTION
## Summary

Typing `g` or `G` in the conversations search box was swallowed (typing "go" produced "o", #166): the session-filter search input bound `g`/`G` to the vim goto-top/bottom list navigation, so they fired before reaching the query.

## Fix

`internal/plugins/conversations/plugin_input.go`: drop the `g`/`G` cases from `updateSearch` so both fall through to the default typing branch, mirroring the arrow-key-only navigation precedent already applied to up/down/h in this input. Added a test that types "go"/"G" in search mode and asserts they land in the query.

Closes #166
